### PR TITLE
Inferring cluster type should not delay command execution

### DIFF
--- a/src/telemetry-helper.ts
+++ b/src/telemetry-helper.ts
@@ -2,8 +2,10 @@ import { reporter } from './telemetry';
 import { Kubectl } from './kubectl';
 
 export function telemetrise(command: string, kubectl: Kubectl, callback: (...args: any[]) => any): (...args: any[]) => any {
-    return async (a) => {
-        reporter.sendTelemetryEvent("command", { command: command, clusterType: await clusterType(kubectl) });
+    return (a) => {
+        clusterType(kubectl).then((ct) =>
+            reporter.sendTelemetryEvent("command", { command: command, clusterType: ct })
+        );
         return callback(a);
     };
 }


### PR DESCRIPTION
When sending telemetry, we attempt to infer the cluster type.  Although we cache aggressively, the first time we do this is quite expensive, and adds 4-5 seconds to the time the _first_ command takes to come up.  After that, it's near instant; but this still creates a painful first experience for users.

The proposed fix is to send the telemetry in _parallel_ with executing the command -- that is, we kick off a task to infer the cluster type and send telemetry, and then execute the command without waiting for this task to complete.

Fixes #420.