### PR TITLE
Having no disabled linters crashed the linting system

### DIFF
--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -154,5 +154,5 @@ export function getDisableLint(): boolean {
 
 export function getDisabledLinters(): string[] {
     const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY);
-    return config['disable-linters'] as string[];
+    return config['disable-linters'] as string[] || [];
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1958,7 +1958,7 @@ function isLintable(document: vscode.TextDocument): boolean {
 }
 
 function linterDisabled(disabledLinters: string[], name: string): boolean {
-    return disabledLinters.some((l) => l === name);
+    return (disabledLinters || []).some((l) => l === name);
 }
 
 async function kubernetesLint(document: vscode.TextDocument): Promise<void> {


### PR DESCRIPTION
This would never have happened if we turned on `strictNullChecks` #oneday #onebeautifulday