### PR TITLE
Add stronger check on binary result

### DIFF
--- a/src/binutilplusplus.ts
+++ b/src/binutilplusplus.ts
@@ -247,7 +247,7 @@ export async function invokeForResult(context: Context, command: string, stdin: 
         return { resultKind: 'exec-failed', execProgram: context.binary, command };
     }
 
-    if (sr.code === 0) {
+    if (sr.code === 0 && sr.stderr === '') {
         return { resultKind: 'exec-succeeded', execProgram: context.binary, command, stdout: sr.stdout };
     }
 


### PR DESCRIPTION
Long story short, if you use an old kubectl binary with a new kubernetes cluster (e.g kubectl 1.15 on kubernetes cluster 1.20.2) the `config view` command may fail

![Screenshot from 2021-04-13 11-37-19](https://user-images.githubusercontent.com/49404737/114541085-8fe1ea00-9c56-11eb-914e-0d691153bf4e.png)

which makes the extension behave in a wrong way (empty tree and a generic json parse error displayed)

This fix allows to show the correct messages to the user
![Screenshot from 2021-04-13 12-37-25](https://user-images.githubusercontent.com/49404737/114541246-bd2e9800-9c56-11eb-822f-ab728bbce0cf.png)
