### PR TITLE
start values completion whenever .Values. occurs.

### DIFF
--- a/src/helm.completionProvider.ts
+++ b/src/helm.completionProvider.ts
@@ -124,7 +124,7 @@ export class HelmTemplateCompletionProvider implements vscode.CompletionItemProv
                 }
                 cache = cache[cur];
             }
-            if (!cache || typeof cache === "string") {
+            if (!cache || typeof cache === "string" || cache.constructor.name === 'Array') {
                 return [];
             }
             const k = _.keys(cache).map((item) =>


### PR DESCRIPTION
Helm values completion didn't work the way I would have expected it to do. Typing `.Values.` or `.Values.service.` and triggering autocompletion by pressing ctrl + space didn't present any actual values. Personally I use autocompletion a lot to explore available values which the new behaviour helps with. The completion didn't show
Old behaviour:
<img width="1136" alt="Bildschirmfoto 2021-10-12 um 20 12 53" src="https://user-images.githubusercontent.com/20975771/137008301-10672c33-8c47-4f3a-8f90-e99588c40151.png">
New behaviour:
<img width="1136" alt="Bildschirmfoto 2021-10-12 um 20 11 49" src="https://user-images.githubusercontent.com/20975771/137008414-735eda98-451e-446c-becd-f5fb4ba14ea4.png">

