### PR TITLE
uodate README to document the hugo microsite

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,10 @@ If you are building and running the extension from source, see [CONTRIBUTING.md]
 
 If you are installing the extension from its VSIX, note that the machine will still need to reach the Visual Studio Marketplace in order to download extension dependencies.  If the machine cannot reach the Marketplace, you will need to install these dependencies manually using their VSIXes.  The list of extension dependencies can be found in `package.json`, in the `extensionDependencies` section.
 
+## Github Pages Website
+
+This project has a simple landing page website (visible at [azure.github.io/vscode-kubernetes-tools](https://azure.github.io/vscode-kubernetes-tools/)) which is [detailed here](https://github.com/Azure/vscode-kubernetes-tools/tree/master/site).
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,15 @@
+# azure.github.io/vscode-kubernetes-tools
+
+This is a simple [Hugo](https://gohugo.io/) one-page website for the vscode-kubernetes-tools Extension. It is hosted via the project repo's [Github Pages config](https://github.com/Azure/vscode-kubernetes-tools/settings/pages).
+
+To update the site, open the `/site` directory and install the dependencies:
+
+* Install Hugo - see the [docs here](https://gohugo.io/getting-started/quick-start/)
+* Install Yarn `npm install --global yarn`
+* Install the other NPM packages by ruinning  `yarn`
+* Run `hugo serve` to run the site in local development
+* Browse to http://localhost:1313/ to view the site locally
+* Make code changes to the site
+* Run `gulp` to recompile the site's assets (CSS, JS)
+* Run `hugo` to rebuild the site, which render the site into the `/public` directory
+* Commit the rebuilt site files to the `gh-pages` [branch](https://github.com/Azure/vscode-kubernetes-tools/tree/gh-pages/) of this repo to update the live site


### PR DESCRIPTION
This PR makes a small edit to the readme, to point to a new sub-readme that explains the little website for this repo: https://azure.github.io/vscode-kubernetes-tools/

That site is generated from the files inside the `site` folder. I've added a README there explaining how Hugo, Gulp and Github Pages generate the site.

Signed-off-by: flynnduism <dev@ronan.design>