### PR TITLE
Do not log values refresh message

### DIFF
--- a/src/helm.completionProvider.ts
+++ b/src/helm.completionProvider.ts
@@ -42,7 +42,6 @@ export class HelmTemplateCompletionProvider implements vscode.CompletionItemProv
     }
 
     private refreshValues(valsYaml: string) {
-        logger.helm.log(`Refresh values cache. Reading ${valsYaml}.`);
         try {
             this.valuesCache = YAML.load(valsYaml);
         } catch (err) {


### PR DESCRIPTION
Do not write message to VSCode Helm Output every time Helm values have been refreshed. Fixes #1026. 