### PR TITLE
Shift dotnet process identification to vscode-omnisharp (#1003)

### DIFF
--- a/debug-on-kubernetes.md
+++ b/debug-on-kubernetes.md
@@ -128,9 +128,7 @@ https://github.com/OmniSharp/omnisharp-vscode/wiki/Attaching-to-remote-processes
 
    2. Notes:
       * `dotnet` debugging is only supported for the `attach` scenario. The `launch` scenario is not yet supported.
-      * If `dotnet` does not show up in debugger picker list, than the extension was able to view the processes running on the container and there were no `dotnet` processes running at that time.
       * If `ps` is not installed on the machine, than `dotnet` will show up in the debugger pick list. If `dotnet` is chosen it will give you an error message with a link to this page.
-      * If `dotnet` is chosen as the debugger and only one `dotnet` process is running on the container, that process will automatically be chosen.  If there is more than one dotnet process running at that time, you will be presented a process pick list, and you can choose the process you would like to debug.
       * The [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) extension is powered by OmniSharp. Find out more information regarding remote debugging with OmniSharp [here](https://github.com/OmniSharp/omnisharp-vscode/wiki/Attaching-to-remote-processes).
       * In case of the `Kubernetes: Debug(Attach)` action is used for debugging, you might need to set the build root of your docker image in order to enable the debugger to map the symbols to your code.
       When you use a docker image to build your code (so the build root differs from the one on your local system) you should set the `vs-kubernetes.dotnet-source-file-map` parameter to add a sourceFileMap entry to the debug configuration.

--- a/src/debug/dotNetDebugProvider.ts
+++ b/src/debug/dotNetDebugProvider.ts
@@ -32,13 +32,11 @@ export class DotNetDebugProvider implements IDebugProvider {
         return false;
     }
 
-    public async startDebugging(workspaceFolder: string, _sessionName: string, _port: number | undefined, pod: string, pidToDebug: number | undefined): Promise<boolean> {
-        const processId = pidToDebug ? pidToDebug.toString() : "${command:pickRemoteProcess}";
+    public async startDebugging(workspaceFolder: string, _sessionName: string, _port: number | undefined, pod: string, _pidToDebug: number | undefined): Promise<boolean> {
         const debugConfiguration: vscode.DebugConfiguration = {
             name: ".NET Core Kubernetes Attach",
             type: "coreclr",
             request: "attach",
-            processId: processId,
             pipeTransport: {
                 pipeProgram: "kubectl",
                 pipeArgs: [ "exec", "-i", pod, "--", "/bin/sh", "-c" ],
@@ -78,9 +76,8 @@ export class DotNetDebugProvider implements IDebugProvider {
         return undefined;
     }
 
-    public filterSupportedProcesses(processes: ProcessInfo[]): ProcessInfo[] | undefined {
-        return processes.filter((processInfo) => (processInfo.command.toLowerCase().startsWith('dotnet ') ||
-                                                  processInfo.command.indexOf('/dotnet ') >= 0)); // full path
+    public filterSupportedProcesses(_processes: ProcessInfo[]): ProcessInfo[] | undefined {
+        return undefined;
     }
 
     public isPortRequired(): boolean {


### PR DESCRIPTION
Previous dotnet debugging implementation looked for processes with
dotnet name only. Since .NET Core 3.1, .NET applications may have a native
executable to launch the app with name that differs from dotnet.

The new implementation doesn't set process id when call vscode-omnisharp
debugger. Now, vscode-omnisharp is used for executing `ps` and showing
vscode UI for choosing process.