### PR TITLE
Exclude **/node_modules/** from Chart.yaml searches

### DIFF
--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -675,7 +675,9 @@ export function pickChartForFile(file: string, options: PickChartUIOptions, fn: 
 }
 
 function findChartFiles() {
-    return vscode.workspace.findFiles("**/Chart.yaml", "", 1024)
+    // Excluding "**/node_modules/**" as a common cause of excessive CPU usage.
+    // https://github.com/microsoft/vscode/issues/75314#issuecomment-503195666
+    return vscode.workspace.findFiles("**/Chart.yaml", "**/node_modules/**", 1024)
 }
 
 // helmExec appends 'args' to a Helm command (helm args...), executes it, and then sends the result to te callback.

--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -573,7 +573,7 @@ export function pickChart(fn: (chartPath: string) => void) {
         vscode.window.showErrorMessage("This command requires an open folder.");
         return;
     }
-    vscode.workspace.findFiles("**/Chart.yaml", "", 1024).then((matches) => {
+    findChartFiles().then((matches) => {
         switch (matches.length) {
             case 0:
                 vscode.window.showErrorMessage("No charts found");
@@ -630,7 +630,7 @@ export function loadChartMetadata(chartDir: string): Chart {
 
 // Given a file, show any charts that this file belongs to.
 export function pickChartForFile(file: string, options: PickChartUIOptions, fn: (path: string) => void) {
-    vscode.workspace.findFiles("**/Chart.yaml", "", 1024).then((matches) => {
+    findChartFiles().then((matches) => {
         switch (matches.length) {
             case 0:
                 if (options.warnIfNoCharts) {
@@ -672,6 +672,10 @@ export function pickChartForFile(file: string, options: PickChartUIOptions, fn: 
                 return;
         }
     });
+}
+
+function findChartFiles() {
+    return vscode.workspace.findFiles("**/Chart.yaml", "", 1024)
 }
 
 // helmExec appends 'args' to a Helm command (helm args...), executes it, and then sends the result to te callback.


### PR DESCRIPTION
This is a strange PR and I would have no qualms with it being rejected.

Unfortunately excluding `**/node_modules/**` from `vscode.workspace.findFiles(...)` calls is somewhat necessary to prevent excessive CPU usage when this extension is installed and users open a large frontend project in VS Code. `findFiles` searches the entire repo by default, even `.gitignore` files.

One comment from a VS Code member recommends extensions exclude `node_modules`, since a proper fix to the `findFiles` API would be a breaking change: https://github.com/microsoft/vscode/issues/75314#issuecomment-503195666

This seems to be somewhat standard, even in extensions that have nothing to do with Node.js. For example:

- Searching `workspace.findFiles` in the `microsoft/vscode` repo shows almost every usage excluding `**/node_modules/**` explicitly. https://github.com/microsoft/vscode/search?q=workspace.findFiles
- This is the case for even the stock Markdown extension: https://github.com/microsoft/vscode/blob/c62f59fcae4d9fd029b542639f3ef58bd698f982/extensions/markdown-language-features/src/features/workspaceSymbolProvider.ts#L40

Would this be reasonable in `vscode-kubernetes-tools` as well?