### PR TITLE
add setting to disable fetching all crds

### DIFF
--- a/package.json
+++ b/package.json
@@ -276,6 +276,14 @@
                             "type": "boolean",
                             "default": false,
                             "description": "Set to true to silence Kubernetes extension recommendation notifications."
+                        },
+                        "vs-kubernetes.smart-code-completion": {
+                            "type": "string",
+                            "enum": [
+                                "enabled",
+                                "disabled"
+                            ],
+                            "description": "Set the smart code completion for CRDs. This would always prevent/allow the plugin to fetch all custom schemas from all CRDs on cluster, despite of their number."
                         }
                     },
                     "default": {

--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
                             "default": false,
                             "description": "Set to true to silence Kubernetes extension recommendation notifications."
                         },
-                        "vs-kubernetes.smart-code-completion": {
+                        "vs-kubernetes.crd-code-completion": {
                             "type": "string",
                             "enum": [
                                 "enabled",

--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -314,6 +314,14 @@ export function ignoreK8sRecommendations(): boolean {
     return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.ignore-recommendations'];
 }
 
-export function getSmartCodeCompletionState(): string | undefined {
-    return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.smart-code-completion'];
+export function getCRDCodeCompletionState(): string | undefined {
+    return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.crd-code-completion'];
+}
+
+export function setCRDCodeCompletion(enable: boolean): void {
+    if (enable) {
+        setConfigValue('vs-kubernetes.crd-code-completion', 'enabled');
+    } else {
+        setConfigValue('vs-kubernetes.crd-code-completion', 'disabled');
+    }
 }

--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -313,3 +313,7 @@ export function suppressKubectlNotFound(): boolean {
 export function ignoreK8sRecommendations(): boolean {
     return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.ignore-recommendations'];
 }
+
+export function getSmartCodeCompletionState(): string | undefined {
+    return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.smart-code-completion'];
+}

--- a/src/kubectlUtils.ts
+++ b/src/kubectlUtils.ts
@@ -222,13 +222,19 @@ export async function getGlobalResources(kubectl: Kubectl, resource: string): Pr
     });
 }
 
-export async function getCRDTypesNumber(kubectl: Kubectl): Promise<number> {
+export async function getCRDTypesNumber(kubectl: Kubectl): Promise<Errorable<number>> {
     const crdTypes = await kubectl.asJson<KubernetesCollection<any>>(`get crd -o json`);
     if (failed(crdTypes)) {
-        return -1;
+        return {
+            succeeded: false,
+            error: crdTypes.error
+        };
     }
 
-    return crdTypes.result.items.length;
+    return {
+        succeeded: true,
+        result: crdTypes.result.items.length
+    };
 }
 
 export async function getCRDTypes(kubectl: Kubectl): Promise<CRD[]> {

--- a/src/kubectlUtils.ts
+++ b/src/kubectlUtils.ts
@@ -222,6 +222,15 @@ export async function getGlobalResources(kubectl: Kubectl, resource: string): Pr
     });
 }
 
+export async function getCRDTypesNumber(kubectl: Kubectl): Promise<number> {
+    const crdTypes = await kubectl.asJson<KubernetesCollection<any>>(`get crd -o json`);
+    if (failed(crdTypes)) {
+        return -1;
+    }
+
+    return crdTypes.result.items.length;
+}
+
 export async function getCRDTypes(kubectl: Kubectl): Promise<CRD[]> {
     const crdTypes = await kubectl.asJson<KubernetesCollection<any>>(`get crd -o json`);
     if (failed(crdTypes)) {

--- a/src/yaml-support/schema-holder.ts
+++ b/src/yaml-support/schema-holder.ts
@@ -41,7 +41,7 @@ export class KubernetesClusterSchemaHolder {
     private async loadSchemaFromActiveCluster(kubectl: Kubectl, schemaEnumFile?: string): Promise<void> {
         const clusterSwagger = await swagger.getClusterSwagger(kubectl);
         const fetchCRDSchemasEnabled = await this.isFetchingCRDsAllowed(kubectl);
-        if (!fetchCRDSchemasEnabled) {
+        if (fetchCRDSchemasEnabled) {
             const crdSchemas = await swagger.getCrdSchemas(kubectl);
             if (crdSchemas) {
                 this.crdSchemas = crdSchemas;

--- a/src/yaml-support/schema-holder.ts
+++ b/src/yaml-support/schema-holder.ts
@@ -8,7 +8,7 @@ import * as swagger from '../components/swagger/swagger';
 import { succeeded } from '../errorable';
 import * as vscode from "vscode";
 import * as util from "./yaml-util";
-import { getCRDCodeCompletionState, setConfigValue, setCRDCodeCompletion } from '../components/config/config';
+import { getCRDCodeCompletionState, setCRDCodeCompletion } from '../components/config/config';
 
 interface KubernetesSchema {
     readonly name: string;

--- a/src/yaml-support/schema-holder.ts
+++ b/src/yaml-support/schema-holder.ts
@@ -8,7 +8,7 @@ import * as swagger from '../components/swagger/swagger';
 import { succeeded } from '../errorable';
 import * as vscode from "vscode";
 import * as util from "./yaml-util";
-import { getSmartCodeCompletionState, setConfigValue } from '../components/config/config';
+import { getCRDCodeCompletionState, setConfigValue, setCRDCodeCompletion } from '../components/config/config';
 
 interface KubernetesSchema {
     readonly name: string;
@@ -52,7 +52,7 @@ export class KubernetesClusterSchemaHolder {
     }
 
     private async isFetchingCRDsAllowed(kubectl: Kubectl): Promise<boolean> {
-        const codeCompletionState = await getSmartCodeCompletionState();
+        const codeCompletionState = await getCRDCodeCompletionState();
         if (codeCompletionState !== undefined) {
             return codeCompletionState === 'enabled';
         }
@@ -62,8 +62,8 @@ export class KubernetesClusterSchemaHolder {
         if (crdsTypesNumber > 50) {
             action = await vscode.window.showInformationMessage(
                 "This cluster contains many CRDs and by fetching them your VSCode instance could slow down. " +
-                "However by disabling CRDs analisys the smart code completion for CR would be automatically disable. " +
-                "Do you want to disable the smart code completion? ",
+                "You may skip fetching the CRDs, but this will disable code completion for custom resources. " +
+                "Do you want to disable the CRD code completion? ",
                 "Disable Once",
                 "Always Disabled",
                 "Enable Once",
@@ -73,10 +73,10 @@ export class KubernetesClusterSchemaHolder {
                 || action === 'Disable Once') {
                 return false;
             } else if (action === 'Always Disabled') {
-                setConfigValue('vs-kubernetes.smart-code-completion', 'disabled');
+                setCRDCodeCompletion(false);
                 return false;
             } else if (action === 'Always Enabled') {
-                setConfigValue('vs-kubernetes.smart-code-completion', 'enabled');
+                setCRDCodeCompletion(true);
             }
         }
 

--- a/src/yaml-support/schema-holder.ts
+++ b/src/yaml-support/schema-holder.ts
@@ -5,7 +5,7 @@ import * as kubectlUtils from '../kubectlUtils';
 import { KUBERNETES_SCHEMA_ENUM_FILE, FALLBACK_SCHEMA_FILE, KUBERNETES_GROUP_VERSION_KIND } from "./yaml-constant";
 import { formatComplex, formatOne, formatType } from '../schema-formatting';
 import * as swagger from '../components/swagger/swagger';
-import { succeeded } from '../errorable';
+import { failed, succeeded } from '../errorable';
 import * as vscode from "vscode";
 import * as util from "./yaml-util";
 import { getCRDCodeCompletionState, setCRDCodeCompletion } from '../components/config/config';
@@ -58,8 +58,11 @@ export class KubernetesClusterSchemaHolder {
         }
 
         const crdsTypesNumber = await kubectlUtils.getCRDTypesNumber(kubectl);
+        if (failed(crdsTypesNumber)) {
+            return false;
+        }
         let action: string | undefined;
-        if (crdsTypesNumber > 50) {
+        if (crdsTypesNumber.result > 50) {
             action = await vscode.window.showInformationMessage(
                 "This cluster contains many CRDs and by fetching them your VSCode instance could slow down. " +
                 "You may skip fetching the CRDs, but this will disable code completion for custom resources. " +


### PR DESCRIPTION
it resolves #1050 

This adds a setting to allow users enabling/disabling the crds fetch when the plugin tries to download all custom schemas. If the general setting is undefined the plugin uses the crds count to decide if to proceed or not and ask the user for confirmation. @itowlson 