### PR TITLE
feat: add log viewer options

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ If you want to skip TLS verification for a particular cluster, you can edit your
 
    * `Kubernetes: Open Dashboard` - Opens the Kubernetes Dashboard in your browser.
    * `Kubernetes: Port Forward` - Prompts user for a local port and a remote port to bind to on a Pod.
-   * `Kubernetes: Select Pod` - It allows to select a pod from a list of pods belonging to the "current" namespace. It can be invoked through command substitution `${command:extension.vsKubernetesSelectPod}`. See [Commands for debugging](https://github.com/Azure/vscode-kubernetes-tools/blob/master/debug-on-kubernetes.md#2-commands-for-debugging) for more details. 
+   * `Kubernetes: Select Pod` - It allows to select a pod from a list of pods belonging to the "current" namespace. It can be invoked through command substitution `${command:extension.vsKubernetesSelectPod}`. See [Commands for debugging](https://github.com/Azure/vscode-kubernetes-tools/blob/master/debug-on-kubernetes.md#2-commands-for-debugging) for more details.
 
 ### Minikube
 
@@ -205,6 +205,9 @@ Minikube tools to be installed and available on your PATH.
    * `checkForMinikubeUpgrade` - On extension startup, notify if a minikube upgrade is available. Defaults to true.
    * `disable-lint` - Disable all linting of Kubernetes files
    * `disable-linters` - Disable specific linters by name
+   * `vscode-kubernetes.log-viewer.follow` - Set to true to follow logs by default in the log viewer.
+   * `vscode-kubernetes.log-viewer.timestamp` - Set to true to show timestamps by default in the log viewer.
+   * `vscode-kubernetes.log-viewer.wrap` - Set to true to wrap lines by default in the log viewer.
 
 ## Custom tool locations
 

--- a/package.json
+++ b/package.json
@@ -381,6 +381,21 @@
                     "scope": "machine",
                     "title": "Minikube path (Linux)",
                     "description": "File path to a minikube binary."
+                },
+                "vscode-kubernetes.log-viewer.follow": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Set to true to follow logs by default in the log viewer."
+                },
+                "vscode-kubernetes.log-viewer.timestamp": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Set to true to show timestamps by default in the log viewer."
+                },
+                "vscode-kubernetes.log-viewer.wrap": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Set to true to wrap lines by default in the log viewer."
                 }
             }
         },

--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -327,10 +327,22 @@ export function isLogViewerFollowEnabled(): boolean {
     return vscode.workspace.getConfiguration('vscode-kubernetes.log-viewer').get('follow', false);
 }
 
+export function setLogViewerFollowEnabled(follow: boolean) {
+    vscode.workspace.getConfiguration('vscode-kubernetes.log-viewer').update('follow', follow, true);
+}
+
 export function isLogViewerTimestampEnabled(): boolean {
     return vscode.workspace.getConfiguration('vscode-kubernetes.log-viewer').get('timestamp', false);
 }
 
+export function setLogViewerTimestampEnabled(timestamp: boolean) {
+    vscode.workspace.getConfiguration('vscode-kubernetes.log-viewer').update('timestamp', timestamp, true);
+}
+
 export function isLogViewerWrapEnabled(): boolean {
     return vscode.workspace.getConfiguration('vscode-kubernetes.log-viewer').get('wrap', false);
+}
+
+export function setLogViewerWrapEnabled(wrap: boolean) {
+    vscode.workspace.getConfiguration('vscode-kubernetes.log-viewer').update('wrap', wrap, true);
 }

--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -129,7 +129,7 @@ export function getToolPath(_host: Host, shell: Shell, tool: string): string | u
 
     const baseKey = toolPathNewBaseKey(tool);
     const osKey = osOverrideKey(os, baseKey);
-    const topLevelToolPath = 
+    const topLevelToolPath =
         userValues[osKey] ||
         defaultValues[osKey] ||
         userValues[baseKey] ||
@@ -319,9 +319,18 @@ export function getCRDCodeCompletionState(): string | undefined {
 }
 
 export function setCRDCodeCompletion(enable: boolean): void {
-    if (enable) {
-        setConfigValue('vs-kubernetes.crd-code-completion', 'enabled');
-    } else {
-        setConfigValue('vs-kubernetes.crd-code-completion', 'disabled');
-    }
+    const value = (enable) ? 'enabled' : 'disabled';
+    setConfigValue('vs-kubernetes.crd-code-completion', value);
+}
+
+export function isLogViewerFollowEnabled(): boolean {
+    return vscode.workspace.getConfiguration('vscode-kubernetes.log-viewer').get('follow', false);
+}
+
+export function isLogViewerTimestampEnabled(): boolean {
+    return vscode.workspace.getConfiguration('vscode-kubernetes.log-viewer').get('timestamp', false);
+}
+
+export function isLogViewerWrapEnabled(): boolean {
+    return vscode.workspace.getConfiguration('vscode-kubernetes.log-viewer').get('wrap', false);
 }

--- a/src/components/logs/app/index.html
+++ b/src/components/logs/app/index.html
@@ -133,6 +133,7 @@
                 <vscode-button id="stopBtn" class="display-none mr-2">Stop</vscode-button>
                 <vscode-button id="clearBtn" class="display-none mr-2">Clear</vscode-button>
                 <vscode-button id="resetBtn" class="mr-2">Reset</vscode-button>
+                <vscode-button id="saveSettingsBtn" class="mr-2">Save Settings</vscode-button>
             </div>
             <div class="tooltip ml-10 mr-2">To terminal:
                 <span class="tooltiptext">Redirect logs to terminal.</span>

--- a/src/components/logs/app/main.js
+++ b/src/components/logs/app/main.js
@@ -14,8 +14,8 @@ window.addEventListener('message', (event) => {
     const message = event.data;
     switch (message.command) {
         case 'init': {
-            const containers = message.containers;
-            schemaColors = JSON.parse(message.colors);
+            const { containers, colors } = message;
+            schemaColors = JSON.parse(colors);
             if (containers.length === 1) {
                 defaultContainer = containers[0];
                 return;
@@ -44,9 +44,55 @@ window.addEventListener('message', (event) => {
             }
             const newContent = text.split('\n');
             updateContent(newContent);
+            break;
+        }
+        case 'reset': {
+            const { follow, timestamp, wrap } = message;
+            setSettings({
+                follow,
+                timestamp,
+                sinceInput: '-1',
+                sinceSelect: 0,
+                tailInput: '-1',
+                terminal: false,
+                wrap
+            });
+            break;
         }
     }
 });
+
+function setSettings(settings) {
+    const { follow, timestamp, sinceInput, sinceSelect, tailInput, terminal, wrap } = settings;
+
+    if (follow !== undefined) {
+        document.getElementById('follow-chk').checked = follow;
+    }
+
+    if (timestamp !== undefined) {
+        document.getElementById('timestamp-chk').checked = timestamp;
+    }
+
+    if (sinceInput !== undefined) {
+        document.getElementById('since-input').value = sinceInput;
+    }
+
+    if (sinceSelect !== undefined) {
+        document.getElementById('since-select').selectedIndex = sinceSelect;
+    }
+
+    if (tailInput !== undefined) {
+        document.getElementById('tail-input').value = tailInput;
+    }
+
+    if (terminal !== undefined) {
+        document.getElementById('terminal-chk').checked = terminal;
+    }
+
+    if (wrap !== undefined) {
+        document.getElementById('wrap-chk').checked = wrap;
+    }
+}
 
 function debounce(func, wait, immediate) {
     let timeout;
@@ -149,6 +195,10 @@ function init() {
         renderByPagination();
     }, 250);
     logPanel.addEventListener("scroll", toBottom);
+
+    vscode.postMessage({
+        command: 'reset'
+    });
 }
 
 function resetContent() {
@@ -249,12 +299,10 @@ function reset() {
     if (containersSelect) {
         containersSelect.selectedIndex = 0;
     }
-    document.getElementById('follow-chk').checked = false;
-    document.getElementById('timestamp-chk').checked = false;
-    document.getElementById('since-input').value = '-1';
-    document.getElementById('since-select').selectedIndex = 0;
-    document.getElementById('tail-input').value = '-1';
-    document.getElementById('terminal-chk').checked = false;
+
+    vscode.postMessage({
+        command: 'reset'
+    });
 }
 
 function updateContent(newContent) {
@@ -269,6 +317,7 @@ function updateContent(newContent) {
             counter++;
         }
     }
+
     content = saveFilteredContent(content);
     setHeightContentPanel();
     renderByPagination(content);

--- a/src/components/logs/app/main.js
+++ b/src/components/logs/app/main.js
@@ -145,6 +145,16 @@ function init() {
         reset();
     });
 
+    const saveSettingsBtn = document.getElementById('saveSettingsBtn');
+    saveSettingsBtn.addEventListener('click', (_event) => {
+        vscode.postMessage({
+            command: 'saveSettings',
+            follow: document.getElementById('follow-chk').checked,
+            timestamp: document.getElementById('timestamp-chk').checked,
+            wrap: document.getElementById('wrap-chk').checked
+        });
+    });
+
     const bottomBtn = document.getElementById('bottomBtn');
     bottomBtn.addEventListener('click', (_event) => {
         scrollToBottom();

--- a/src/components/logs/logsWebview.ts
+++ b/src/components/logs/logsWebview.ts
@@ -6,6 +6,7 @@ import { fs } from '../../fs';
 import { Container } from '../../kuberesources.objectmodel';
 import { Kubectl } from '../../kubectl';
 import { getLogsForContainer, LogsDisplayMode } from '../kubectl/logs';
+import { isLogViewerFollowEnabled, isLogViewerTimestampEnabled, isLogViewerWrapEnabled } from '../config/config';
 
 export class LogsPanel extends WebPanel {
     public static readonly viewType = 'vscodeKubernetesLogs';
@@ -141,10 +142,9 @@ export class LogsPanel extends WebPanel {
     }
 
     private getLogViewerOptions(): object {
-        const configuration = vscode.workspace.getConfiguration();
-        const follow = configuration.get('vscode-kubernetes.log-viewer.follow', false);
-        const timestamp = configuration.get('vscode-kubernetes.log-viewer.timestamp', false);
-        const wrap = configuration.get('vscode-kubernetes.log-viewer.wrap', false);
+        const follow = isLogViewerFollowEnabled();
+        const timestamp = isLogViewerTimestampEnabled();
+        const wrap = isLogViewerWrapEnabled();
 
         return {
             follow,

--- a/src/components/logs/logsWebview.ts
+++ b/src/components/logs/logsWebview.ts
@@ -6,7 +6,7 @@ import { fs } from '../../fs';
 import { Container } from '../../kuberesources.objectmodel';
 import { Kubectl } from '../../kubectl';
 import { getLogsForContainer, LogsDisplayMode } from '../kubectl/logs';
-import { isLogViewerFollowEnabled, isLogViewerTimestampEnabled, isLogViewerWrapEnabled } from '../config/config';
+import { isLogViewerFollowEnabled, setLogViewerFollowEnabled, isLogViewerTimestampEnabled, setLogViewerTimestampEnabled, isLogViewerWrapEnabled, setLogViewerWrapEnabled } from '../config/config';
 
 export class LogsPanel extends WebPanel {
     public static readonly viewType = 'vscodeKubernetesLogs';
@@ -65,12 +65,17 @@ export class LogsPanel extends WebPanel {
                     break;
                 }
                 case 'reset': {
-                    const logViewerOptions = this.getLogViewerOptions();
+                    const logViewerOptions = this.getLogViewerSettings();
 
                     this.panel.webview.postMessage({
                         command: 'reset',
                         ...logViewerOptions
                     });
+                    break;
+                }
+                case 'saveSettings': {
+                    const { follow, timestamp, wrap } = event;
+                    this.saveLogViewerSettings(follow, timestamp, wrap);
                     break;
                 }
             }
@@ -141,7 +146,7 @@ export class LogsPanel extends WebPanel {
             .replace('<!-- meta http-equiv="Content-Security-Policy" -->', meta);
     }
 
-    private getLogViewerOptions(): object {
+    private getLogViewerSettings(): object {
         const follow = isLogViewerFollowEnabled();
         const timestamp = isLogViewerTimestampEnabled();
         const wrap = isLogViewerWrapEnabled();
@@ -151,5 +156,13 @@ export class LogsPanel extends WebPanel {
             timestamp,
             wrap
         };
+    }
+
+    private saveLogViewerSettings(follow: boolean, timestamp: boolean, wrap: boolean): void {
+        setLogViewerFollowEnabled(follow);
+        setLogViewerTimestampEnabled(timestamp);
+        setLogViewerWrapEnabled(wrap);
+
+        vscode.window.showInformationMessage('Succesfully saved default log viewer settings.');
     }
 }


### PR DESCRIPTION
Whenever I view the logs of a pod, I always set the same options pretty much. ^-^'
This just creates some global settings which sets the default log viewer options.

For now, it only covers `follow`, `timestamp` and `wrap`.
I'm considering doing others later, but figured for now this would be nice.

It looks to me (though I didn't check manually) that the `reset()` method wasn't resetting the `wrap` checkbox anyway, so this also fixes that.

### Related
* Partially resolves x https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1058#issue-1204480246
  * I can also make an option to run by default on viewing logs too after/if this is merged.