### PR TITLE
feat: add option to run automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Minikube tools to be installed and available on your PATH.
    * `vscode-kubernetes.log-viewer.follow` - Set to true to follow logs by default in the log viewer.
    * `vscode-kubernetes.log-viewer.timestamp` - Set to true to show timestamps by default in the log viewer.
    * `vscode-kubernetes.log-viewer.wrap` - Set to true to wrap lines by default in the log viewer.
+   * `vscode-kubernetes.log-viewer.autorun` - Set to true to automatically begin fetching logs once the log viewer is opened using the default settings.
 
 ## Custom tool locations
 

--- a/package.json
+++ b/package.json
@@ -396,6 +396,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Set to true to wrap lines by default in the log viewer."
+                },
+                "vscode-kubernetes.log-viewer.autorun": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Set to true to automatically begin fetching logs once the log viewer is opened using the default settings."
                 }
             }
         },

--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -346,3 +346,7 @@ export function isLogViewerWrapEnabled(): boolean {
 export function setLogViewerWrapEnabled(wrap: boolean) {
     vscode.workspace.getConfiguration('vscode-kubernetes.log-viewer').update('wrap', wrap, true);
 }
+
+export function isLogViewerAutorunEnabled(): boolean {
+    return vscode.workspace.getConfiguration('vscode-kubernetes.log-viewer').get('autorun', false);
+}

--- a/src/components/logs/app/main.js
+++ b/src/components/logs/app/main.js
@@ -59,6 +59,10 @@ window.addEventListener('message', (event) => {
             });
             break;
         }
+        case 'run': {
+            onRun();
+            break;
+        }
     }
 });
 
@@ -120,12 +124,14 @@ function createElement(type, value, content) {
     return element;
 }
 
+function onRun() {
+    changeVisibilityAfterRun();
+    startLog();
+}
+
 function init() {
     const runBtn = document.getElementById('runBtn');
-    runBtn.addEventListener('click', (_event) => {
-        changeVisibilityAfterRun();
-        startLog();
-    });
+    runBtn.addEventListener('click', onRun);
 
     const stopBtn = document.getElementById('stopBtn');
     stopBtn.addEventListener('click', (_event) => {
@@ -207,7 +213,7 @@ function init() {
     logPanel.addEventListener("scroll", toBottom);
 
     vscode.postMessage({
-        command: 'reset'
+        command: 'postInitialize'
     });
 }
 

--- a/src/components/logs/logsWebview.ts
+++ b/src/components/logs/logsWebview.ts
@@ -6,7 +6,7 @@ import { fs } from '../../fs';
 import { Container } from '../../kuberesources.objectmodel';
 import { Kubectl } from '../../kubectl';
 import { getLogsForContainer, LogsDisplayMode } from '../kubectl/logs';
-import { isLogViewerFollowEnabled, setLogViewerFollowEnabled, isLogViewerTimestampEnabled, setLogViewerTimestampEnabled, isLogViewerWrapEnabled, setLogViewerWrapEnabled } from '../config/config';
+import { isLogViewerFollowEnabled, setLogViewerFollowEnabled, isLogViewerTimestampEnabled, setLogViewerTimestampEnabled, isLogViewerWrapEnabled, setLogViewerWrapEnabled, isLogViewerAutorunEnabled } from '../config/config';
 
 export class LogsPanel extends WebPanel {
     public static readonly viewType = 'vscodeKubernetesLogs';
@@ -65,12 +65,18 @@ export class LogsPanel extends WebPanel {
                     break;
                 }
                 case 'reset': {
-                    const logViewerOptions = this.getLogViewerSettings();
+                    this.resetWebviewSettings();
+                    break;
+                }
+                case 'postInitialize': {
+                    this.resetWebviewSettings();
+                    const isAutorunEnabled = isLogViewerAutorunEnabled();
 
-                    this.panel.webview.postMessage({
-                        command: 'reset',
-                        ...logViewerOptions
-                    });
+                    if (isAutorunEnabled) {
+                        this.panel.webview.postMessage({
+                            command: 'run',
+                        });
+                    }
                     break;
                 }
                 case 'saveSettings': {
@@ -79,6 +85,15 @@ export class LogsPanel extends WebPanel {
                     break;
                 }
             }
+        });
+    }
+
+    private resetWebviewSettings() {
+        const logViewerOptions = this.getLogViewerSettings();
+
+        this.panel.webview.postMessage({
+            command: 'reset',
+            ...logViewerOptions
         });
     }
 


### PR DESCRIPTION
Adds a setting to automatically run the log viewer using the default settings once the viewer has finished initializing.

### Related
* Partially solves x https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1058
  * Still missing a setting to scroll to bottom by default.