### PR TITLE
Fix unresponsive UI after getting CRD json

### DIFF
--- a/src/components/clusterexplorer/node.folder.crdtypes.ts
+++ b/src/components/clusterexplorer/node.folder.crdtypes.ts
@@ -2,7 +2,6 @@ import { Kubectl } from '../../kubectl';
 import * as kubectlUtils from '../../kubectlUtils';
 import { Host } from '../../host';
 import * as kuberesources from '../../kuberesources';
-import { CRD } from '../../kuberesources.objectmodel';
 import { ClusterExplorerNode } from './node';
 import { GroupingFolderNode } from './node.folder.grouping';
 import { ResourceFolderNode } from './node.folder.resource';
@@ -13,13 +12,6 @@ export class CRDTypesFolderNode extends GroupingFolderNode {
     }
     async getChildren(kubectl: Kubectl, _host: Host): Promise<ClusterExplorerNode[]> {
         const objects = await kubectlUtils.getCRDTypes(kubectl);
-        return objects.map((obj) => ResourceFolderNode.create(this.customResourceKind(obj)));
-    }
-    private customResourceKind(crd: CRD): kuberesources.ResourceKind {
-        return new kuberesources.ResourceKind(crd.spec.names.singular, crd.spec.names.plural, crd.spec.names.kind, this.safeAbbreviation(crd), crd.spec.names.plural);
-    }
-    private safeAbbreviation(crd: CRD): string {
-        const shortNames = crd.spec.names.shortNames;
-        return (shortNames && shortNames.length > 0) ? shortNames[0] : crd.metadata.name;
+        return objects.map(ResourceFolderNode.create);
     }
 }

--- a/src/kubectlUtils.ts
+++ b/src/kubectlUtils.ts
@@ -238,7 +238,7 @@ export async function getCRDTypesNumber(kubectl: Kubectl): Promise<Errorable<num
 }
 
 export async function getCRDTypes(kubectl: Kubectl): Promise<ResourceKind[]> {
-    const crds = await kubectl.asLines(`get crd -o jsonpath="{range .items[*]}{.metadata.name}{\\" \\"}{.spec.names.kind}{\\" \\"}{.spec.names.singular}{\\" \\"}{.spec.names.plural}{\\" \\"}{.spec.names.shortNames}{\\"\\n\\"}{end}"`);
+    const crds = await kubectl.asLines(`get crd -o jsonpath="{range .items[*]}{.metadata.name}{\\" \\"}{.spec.names.kind}{\\" \\"}{.spec.names.singular}{\\" \\"}{.spec.names.plural}{\\" \\"}{range .spec.names.shortNames}{@}{end}{\\"\\n\\"}{end}"`);
     if (failed(crds)) {
         vscode.window.showErrorMessage(crds.error[0]);
         return [];

--- a/src/kuberesources.objectmodel.ts
+++ b/src/kuberesources.objectmodel.ts
@@ -63,21 +63,6 @@ export interface ContainerStatus {
     readonly ready: boolean;
 }
 
-export interface CRD extends KubernetesResource {
-    readonly spec: CRDSpec;
-}
-
-export interface CRDSpec {
-    readonly names: CRDNames;
-}
-
-export interface CRDNames {
-    readonly kind: string;
-    readonly plural: string;
-    readonly singular: string;
-    readonly shortNames: string[];
-}
-
 function isObjectMeta(obj: any): obj is ObjectMeta {
     return obj && obj.name;
 }


### PR DESCRIPTION
This addresses a problem that happens:
- on Windows
- on a cluster with a large number of CRDs (~80 in my case)

**Symptom**

The UI becomes completely unresponsive for well over a minute, in a couple of places:
- immediately *after* the new (#1059) CRD popup appears (making it impossible to make the choice about fetching CRDs until it's recovered).
- after expanding the 'Custom Resources' item.

These are both times when the code invokes `kubectl get crd -o json`.

Interestingly, nothing much seems to be happening at the time it hangs. Both the `kubectl` call and the JSON parsing have already completed. It appears to happen on the first `await` after those things have happened, so my best guess is that parsing the massive json array created a lot of detritus in memory, and the unresponsiveness is down to the garbage collector kicking in.

**Fix**

Whatever the cause, the fix I'm proposing here is to minimize the length of stdout produced by the `kubectl` calls, which seems to make the problem go away.

