### PR TITLE
rework: make "that match" default option

### DIFF
--- a/src/components/logs/app/index.html
+++ b/src/components/logs/app/index.html
@@ -143,14 +143,13 @@
         <div class="mt-5">
             <span class="mr-2">Filter:</span>
             <vscode-select id="filter-select" class="w-130 mr-2">
-                <vscode-option value="all" selected>all</vscode-option>
-                <vscode-option value="include">that match</vscode-option>
+                <vscode-option value="include" selected>that match</vscode-option>
                 <vscode-option value="exclude">that don't match</vscode-option>
                 <vscode-option value="after">after match</vscode-option>
                 <vscode-option value="before">before match</vscode-option>
             </vscode-select>
             <div class="mr-2" style="width: 350px; display: inline-block">
-                <vscode-inputbox placeholder="Enter your key words" id="filter-input"></vscode-inputbox>
+                <vscode-inputbox placeholder="Enter your keywords" id="filter-input"></vscode-inputbox>
             </div>
 
             <div class="tooltip ml-10 mr-2">Wrap lines:

--- a/src/components/logs/app/main.js
+++ b/src/components/logs/app/main.js
@@ -180,7 +180,7 @@ function init() {
     const filterSelect = document.getElementById('filter-select');
     filterSelect.addEventListener('vsc-change', (_event) => {
         resetFilter();
-        if (isRun() && document.getElementById('filter-input').value) {
+        if (isRun() && isFiltering()) {
             runFilter();
         }
     });
@@ -188,7 +188,7 @@ function init() {
     const filterInput = document.getElementById('filter-input');
     filterInput.addEventListener('keyup', (_event) => {
         resetFilter();
-        if (!isRun() || document.getElementById('filter-select').value === 'all') {
+        if (!isRun()) {
             return;
         }
         if (typingTimer) {
@@ -270,10 +270,9 @@ function isRun() {
     return document.getElementById('runBtn').classList.contains('display-none');
 }
 
-function isFilterEnabled() {
+function isFiltering() {
     const filterInput = document.getElementById('filter-input').value;
-    const mode = document.getElementById('filter-select').value;
-    return filterInput.length > 0 && mode !== 'all';
+    return filterInput.length > 0;
 }
 
 function startLog() {
@@ -344,7 +343,7 @@ function setHeightContentPanel(removeStyle) {
     if (removeStyle) {
         document.getElementById('innerLogPanel').style.removeProperty('height');
     } else {
-        const content = isFilterEnabled() ? filteredContent : fullPageContent;
+        const content = isFiltering() ? filteredContent : fullPageContent;
         const rows = Object.keys(content).length;
         const heightDiv = getDefaultDivHeightValue();
         document.getElementById('innerLogPanel').style.height = `${heightDiv * rows}px`;
@@ -352,10 +351,8 @@ function setHeightContentPanel(removeStyle) {
 }
 
 function saveFilteredContent(content) {
-    const filterInput = document.getElementById('filter-input').value;
-    const mode = document.getElementById('filter-select').value;
     let contentAfterFilter;
-    if (filterInput.length > 0 && mode !== 'all') {
+    if (isFiltering()) {
         contentAfterFilter = filter(content);
         let fcRows = Object.keys(filteredContent).length - 1;
         if (fcRows === -1) {
@@ -375,7 +372,7 @@ function filter(logs) {
     const filterInput = document.getElementById('filter-input').value;
     const mode = document.getElementById('filter-select').value;
     let content = {};
-    if (filterInput.length > 0 && mode !== 'all') {
+    if (filterInput.length > 0) {
         const regex = new RegExp(filterInput);
         switch (mode) {
             case 'include':
@@ -481,7 +478,7 @@ function renderByPagination(contentToAdd) {
     if (contentToAdd && Object.keys(contentToAdd).length === 0) {
         return;
     }
-    const fullFilteredContent = isFilterEnabled() ? filteredContent : fullPageContent;
+    const fullFilteredContent = isFiltering() ? filteredContent : fullPageContent;
     const totalRows = Object.keys(fullFilteredContent).length - 1;
     const heightDiv = getDefaultDivHeightValue();
     const currentPosition = document.getElementById('logPanel').scrollTop;


### PR DESCRIPTION
### Keywords

* "key words" → "keywords"
  * https://www.wordnik.com/words/keyword
  * https://www.dictionary.com/browse/keywords
  * https://en.wikipedia.org/wiki/Keyword

### Filter Select

I removed the "all" option, as I felt this was unnecessary.

A more intuitive way to handle this is to not apply a filter if the text boxes value is empty rather than a dedicated `all` value. An empty text box, similar to the value `-1` in a numerical text box, is generally implied as unset. (Even if a user were to interpret it otherwise, an empty string or regex matches all logs.)

Now when a user wants to filter logs, they only have to set 1 field instead of 2. (Unless they want to use a different filter mode.)

I firmly believe this improves the user-experience with the extension, but am happy to revert that if maintainers disagree.