### PR TITLE
fix: make word-wrap actually wrap lines

### DIFF
--- a/src/components/logs/app/index.html
+++ b/src/components/logs/app/index.html
@@ -67,6 +67,7 @@
         }
         .white-space-wrap {
             white-space: pre-wrap;
+            word-wrap: anywhere;
         }
         #content {
             color: var(--vscode-foreground)

--- a/src/components/logs/app/main.js
+++ b/src/components/logs/app/main.js
@@ -174,13 +174,11 @@ function init() {
     });
 
     const wrapChk = document.getElementById('wrap-chk');
-    wrapChk.addEventListener('vsc-change', function (event) {
+    wrapChk.addEventListener('vsc-change', (event) => {
         if (event.detail.checked) {
-            document.getElementById('content').classList.remove('white-space-pre');
-            document.getElementById('content').classList.add('white-space-wrap');
+            switchClass('content', 'white-space-pre', 'white-space-wrap');
         } else {
-            document.getElementById('content').classList.remove('white-space-wrap');
-            document.getElementById('content').classList.add('white-space-pre');
+            switchClass('content', 'white-space-wrap', 'white-space-pre');
         }
     });
 


### PR DESCRIPTION
### Word Wrap

Word wrap only _partially_ wrapped lines before.
Before it would only split lines by word boundaries (i.e. whitespace or hyphens), for example, long words or minified JSON would still extend over and require a horizontal scrollbar to view the full log. (Which kinda defeats the point of word wrapping since the goal is to avoid horizontal scrolling.)

![Untitled](https://user-images.githubusercontent.com/22801583/168488960-bd4a2f8f-11ac-4676-b167-8688d8c29020.png)

This adds `overflow-wrap: anywhere` which tells the view that it's ok to split in the middle of words. Now users won't experience a horizontal scroll bar at all when word-wrap is enabled!

More info:
* https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap

### Related
* https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/pull/1076 Originally a part of this, but was split off.