### PR TITLE
Use XDG Base Directory variables when creating the base installation directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,10 @@ The following directives are supported:
 * `exclude`: Do not treat this file as a Kubernetes manifest. This is useful when you have
   files that look a lot like Kubernetes manifests but aren't, such as Kustomize patch files.
 
+## Extension data
+
+This extension stores its associated files and data in `$XDG_STATE_HOME/vs-kubernetes` (at `~/.local/state/vs-kubernetes` by default). However, if the legacy directory of `~/.vs-kubernetes` still exists, then that will be used instead. 
+
 ## Known issues
 
   * `Kubernetes: Debug` command currently works only with Go, Node.js, Java, Python and .NET applications

--- a/src/components/installer/installationlayout.ts
+++ b/src/components/installer/installationlayout.ts
@@ -1,9 +1,25 @@
+import * as os from 'os';
 import * as path from 'path';
 
+import { fs } from '../../fs';
 import { Platform, Shell } from "../../shell";
 
+export function vsKubernetesFolder(shell: Shell): string {
+    const originalDir = path.join(shell.home(), `.vs-kubernetes`);
+
+    if (fs.existsSync(originalDir) || os.platform() !== `linux`) {
+        return originalDir;
+    }
+
+    let xdgStateHome = process.env.XDG_STATE_HOME || ``;
+    if (xdgStateHome[0] !== `/`) {
+        xdgStateHome = path.join(os.homedir(), `.local/state`);
+    }
+    return path.join(xdgStateHome, `vs-kubernetes`);
+}
+
 export function baseInstallFolder(shell: Shell): string {
-    return path.join(shell.home(), `.vs-kubernetes/tools`);
+    return path.join(vsKubernetesFolder(shell), `tools`);
 }
 
 export function getInstallFolder(shell: Shell, tool: string): string {

--- a/src/components/kubectl/autoversion.ts
+++ b/src/components/kubectl/autoversion.ts
@@ -13,7 +13,7 @@ import { getKubeconfigPath } from '../kubectl/kubeconfig';
 import { getToolPath } from '../config/config';
 import { Host } from '../../host';
 import { mkdirpAsync } from '../../utils/mkdirp';
-import { platformUrlString, formatBin, platformArch } from '../installer/installationlayout';
+import { platformUrlString, formatBin, platformArch, vsKubernetesFolder } from '../installer/installationlayout';
 import * as installer from '../installer/installer';
 import { ExecResult } from '../../binutilplusplus';
 
@@ -54,7 +54,7 @@ export async function ensureSuitableKubectl(kubectl: Kubectl, shell: Shell, host
 }
 
 function getBasePath(shell: Shell): string {
-    return path.join(shell.home(), `.vs-kubernetes/tools/kubectl/autoversion`);
+    return path.join(vsKubernetesFolder(shell), `tools/kubectl/autoversion`);
 }
 
 function getCachePath(shell: Shell): string {


### PR DESCRIPTION
The [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) specifies various user directories for applications to store data. There are a lot of [good reasons](https://xdgbasedirectoryspecification.com) to support this, and this PR adds support in a backwards-compatible way

- This PR adheres to the spec by creating the `vs-kubernetes` directory in `~/.local/state`, but _only if_ a directory has not been created at `~/.vs-kubernetes` _and_ the current platform is Linux
  - In the case where we can follow the XDG Base Directory Specification, users can customize where the `vs-kubernetes` directory is created with the `XDG_STATE_HOME` variable. If the env var is empty or if it's a relative path (as per the spec), the default of `~/.local/state` is used