### PR TITLE
Set debug session name to pod name on attach

### DIFF
--- a/src/debug/debugSession.ts
+++ b/src/debug/debugSession.ts
@@ -91,7 +91,7 @@ export class DebugSession implements IDebugSession {
         }
 
         vscode.window.withProgress({ location: vscode.ProgressLocation.Window }, async (p) => {
-            let appName;
+            let appName: string | undefined;
             try {
                 // Build/push docker image.
                 p.report({ message: "Building Docker image..."});
@@ -121,7 +121,10 @@ export class DebugSession implements IDebugSession {
 
                 // Start debug session.
                 p.report({ message: `Starting ${this.debugProvider!.getDebuggerType()} debug session...`});  // safe because checked outside the lambda
-                await this.startDebugSession(appName, cwd, proxyResult, podName, undefined);
+                await this.startDebugSession(appName, cwd, proxyResult, podName, undefined, async () => {
+                    kubeChannel.showOutput("The debug session exited.");
+                    await this.promptForCleanup(`deployment/${appName}`);
+                });
             } catch (error) {
                 vscode.window.showErrorMessage(error);
                 kubeChannel.showOutput(`Debug on Kubernetes failed. The errors were: ${error}.`);
@@ -196,7 +199,7 @@ export class DebugSession implements IDebugSession {
                 // Start debug session.
                 p.report({ message: `Starting ${this.debugProvider!.getDebuggerType()} debug session...`});  // safe because checked outside lambda
 
-                await this.startDebugSession(targetPod, workspaceFolder.uri.fsPath, proxyResult, targetPod, pidToDebug);
+                await this.startDebugSession(targetPod, workspaceFolder.uri.fsPath, proxyResult, targetPod, pidToDebug, async () => {});
             } catch (error) {
                 vscode.window.showErrorMessage(error);
                 kubeChannel.showOutput(`Debug on Kubernetes failed. The errors were: ${error}.`);
@@ -350,9 +353,8 @@ export class DebugSession implements IDebugSession {
         return proxyResult;
     }
 
-    private async startDebugSession(appName: string | undefined, cwd: string, proxyResult: ProxyResult | undefined, pod: string, pidToDebug: number | undefined): Promise<void> {
+    private async startDebugSession(sessionName: string, cwd: string, proxyResult: ProxyResult | undefined, pod: string, pidToDebug: number | undefined, onTerminateCallback: () => Promise<any>): Promise<void> {
         kubeChannel.showOutput("Starting debug session...", "Start debug session");
-        const sessionName = appName || `${Date.now()}`;
 
         const proxyDebugPort = proxyResult ? proxyResult.proxyDebugPort : undefined;
         const proxyAppPort = proxyResult ? proxyResult.proxyAppPort : undefined;
@@ -361,10 +363,7 @@ export class DebugSession implements IDebugSession {
             if (proxyResult && proxyResult.proxyProcess) {
                 proxyResult.proxyProcess.kill();
             }
-            if (appName) {
-                kubeChannel.showOutput("The debug session exited.");
-                await this.promptForCleanup(`deployment/${appName}`);
-            }
+            await onTerminateCallback();
         });
     }
 

--- a/src/debug/debugSession.ts
+++ b/src/debug/debugSession.ts
@@ -196,7 +196,7 @@ export class DebugSession implements IDebugSession {
                 // Start debug session.
                 p.report({ message: `Starting ${this.debugProvider!.getDebuggerType()} debug session...`});  // safe because checked outside lambda
 
-                await this.startDebugSession(undefined, workspaceFolder.uri.fsPath, proxyResult, targetPod, pidToDebug);
+                await this.startDebugSession(targetPod, workspaceFolder.uri.fsPath, proxyResult, targetPod, pidToDebug);
             } catch (error) {
                 vscode.window.showErrorMessage(error);
                 kubeChannel.showOutput(`Debug on Kubernetes failed. The errors were: ${error}.`);


### PR DESCRIPTION
This change sets the target kubernetes pod's name as the default name for the debug session when using the "Debug (Attach)".

Currently, by passing in 'undefined' it's falling back to a numeric datetime value as the debug session name and when attaching debuggers to multiple containers this becomes very confusing for the user.
 