### PR TITLE
Add inline buttons for describe, logs, and terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -627,6 +627,11 @@
                 },
                 {
                     "command": "extension.vsKubernetesDescribe",
+                    "group": "inline",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.resource(?!\\.namespace).*/i"
+                },
+                {
+                    "command": "extension.vsKubernetesDescribe",
                     "group": "3",
                     "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.resource(?!\\.namespace).*/i"
                 },
@@ -638,6 +643,11 @@
                 {
                     "command": "extension.vsKubernetesDeleteNow",
                     "group": "2@3",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.resource\\.pod/i"
+                },
+                {
+                    "command": "extension.vsKubernetesTerminal",
+                    "group": "inline",
                     "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.resource\\.pod/i"
                 },
                 {
@@ -674,6 +684,11 @@
                     "command": "extension.vsKubernetesScale",
                     "group": "2@6",
                     "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.resource\\.(deployment|job|rc|rs|statefulset)/i"
+                },
+                {
+                    "command": "extension.vsKubernetesLogs",
+                    "group": "inline",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.resource\\.(pod|job)/i"
                 },
                 {
                     "command": "extension.vsKubernetesLogs",
@@ -914,7 +929,8 @@
             {
                 "command": "extension.vsKubernetesLogs",
                 "title": "Logs",
-                "category": "Kubernetes"
+                "category": "Kubernetes",
+                "icon": "$(list-flat)"
             },
             {
                 "command": "extension.vsKubernetesExpose",
@@ -924,7 +940,8 @@
             {
                 "command": "extension.vsKubernetesDescribe",
                 "title": "Describe",
-                "category": "Kubernetes"
+                "category": "Kubernetes",
+                "icon": "$(eye)"
             },
             {
                 "command": "extension.vsKubernetesSync",
@@ -939,7 +956,8 @@
             {
                 "command": "extension.vsKubernetesTerminal",
                 "title": "Terminal",
-                "category": "Kubernetes"
+                "category": "Kubernetes",
+                "icon": "$(terminal)"
             },
             {
                 "command": "extension.vsKubernetesDiff",


### PR DESCRIPTION
In our small development team I noticed our interactions with K8S commonly boils down to three tasks: describing a pod to see its status, viewing its logs (and not needing to type a lengthy `kubectl` command!) and occasionally jumping into a terminal to play with args for probes manually.

This PR adds those commands to the inline group to make them easier to reach than the context menu:
![image](https://user-images.githubusercontent.com/7294642/202893815-38de29a5-c256-46a4-9931-dcd1fb0ca0a7.png)

(If this isn't desirable feel free to close! 🙂)