### PR TITLE
Update readme to stable path for kubectl/helm/minikube.

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,10 +186,10 @@ Minikube tools to be installed and available on your PATH.
 
    * `vs-kubernetes` - Parent for Kubernetes-related extension settings
        * `vs-kubernetes.namespace` - The namespace to use for all commands
-       * `vs-kubernetes.kubectl-path` - File path to the kubectl binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
+       * `vscode-kubernetes.kubectl-path` - File path to the kubectl binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
        * `vs-kubernetes.helm-path` - File path to the helm binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
        * `vs-kubernetes.minikube-path` - File path to the minikube binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
-       * `vs-kubernetes.kubectlVersioning` - By default, the extension uses the `kubectl` binary you provide on the system PATH or in the `vs-kubernetes.kubectl-path` configuration setting. If you set this setting to `infer`, then for each cluster the extension will attempt to identify the cluster version and download a compatible `kubectl` binary.  This improves compatibility if you have multiple Kubernetes versions in play, but may be slower.  **Note:** this setting is checked only when the extension loads; if you change it, you must reload the extension.
+       * `vs-kubernetes.kubectlVersioning` - By default, the extension uses the `kubectl` binary you provide on the system PATH or in the `vscode-kubernetes.kubectl-path` configuration setting. If you set this setting to `infer`, then for each cluster the extension will attempt to identify the cluster version and download a compatible `kubectl` binary.  This improves compatibility if you have multiple Kubernetes versions in play, but may be slower.  **Note:** this setting is checked only when the extension loads; if you change it, you must reload the extension.
        * `vs-kubernetes.kubeconfig` - File path to the kubeconfig file you want to use. This overrides both the default kubeconfig and the KUBECONFIG environment variable.
        * `vs-kubernetes.knownKubeconfigs` - An array of file paths of kubeconfig files that you want to be able to quickly switch between using the Set Kubeconfig command.
        * `vs-kubernetes.autoCleanupOnDebugTerminate` - The flag to control whether to auto cleanup the created deployment and associated pod by the command "Kubernetes: Debug (Launch)". The cleanup action occurs when it failed to start debug session or debug session terminated. If not specified, the extension will prompt for whether to clean up or not. You might choose not to clean up if you wanted to view pod logs, etc.
@@ -226,9 +226,9 @@ If you are working with Azure Container Services or Azure Kubernetes Services, t
 
 If you move your configuration file between machines with different OSes (and therefore different paths to binaries) you can override the following settings on a per-OS basis by appending `.windows`, `.mac` or `.linux` to the setting name:
 
-  * `vs-kubernetes.kubectl-path`
-  * `vs-kubernetes.helm-path`
-  * `vs-kubernetes.minikube-path`
+  * `vscode-kubernetes.kubectl-path`
+  * `vscode-kubernetes.helm-path`
+  * `vscode-kubernetes.minikube-path`
 
 For example, consider the following settings file:
 

--- a/src/components/clusterprovider/azure/azureclusterprovider.ts
+++ b/src/components/clusterprovider/azure/azureclusterprovider.ts
@@ -291,7 +291,7 @@ function renderConfigurationResult(configureResult: ActionResult<azure.Configure
     }
 
     const pathMessage = configResult.cliOnDefaultPath ? '' :
-        '<p>This location is not on your system PATH. Add this directory to your path, or set the VS Code <b>vs-kubernetes.kubectl-path</b> config setting.</p>';
+        '<p>This location is not on your system PATH. Add this directory to your path, or set the VS Code <b>vscode-kubernetes.kubectl-path</b> config setting.</p>';
     const getCliOutput = configResult.gotCli ?
         `<p class='success'>kubectl installed at ${configResult.cliInstallFile}</p>${pathMessage}` :
         `<p class='error'>An error occurred while downloading kubectl.</p>


### PR DESCRIPTION
Thank you so much in advance for taking a look at this PR, this PR updates readme to to the non-deprecated settings path for `kubectl, helm and Minikube` 

I found this while trying to replicate an issue which is noon-issue if path is set correctly, or extension defaults are set from the extension installs. https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1132  **deprecated information** here: https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/blob/master/package.json#L114

Thanks heaps ❤️☕️🙏🎊 , a gentle ping and cc: @lstocchi , @squillace , @itowlson or @gambtho 