### PR TITLE
added limited support for initContainers (logging)

### DIFF
--- a/src/components/clusterexplorer/resourcekinds/resourcekind.pod.ts
+++ b/src/components/clusterexplorer/resourcekinds/resourcekind.pod.ts
@@ -19,7 +19,7 @@ export const podUICustomiser = {
 };
 
 // getIconForPodStatus takes status and ready values and returns an appropriate icon uri
-// Currently, supported/expected status values are running and complete, others return error condition.
+// Currently, supported/expected status values are running, completed and init, other values return error condition.
 // The expected value for "ready" is two digits, ready and total number of containers, which are separated by a "/" character.
 function getIconForPodStatus(status: string, ready: string): vscode.Uri {
     console.log(status);

--- a/src/components/clusterexplorer/resourcekinds/resourcekind.pod.ts
+++ b/src/components/clusterexplorer/resourcekinds/resourcekind.pod.ts
@@ -22,7 +22,6 @@ export const podUICustomiser = {
 // Currently, supported/expected status values are running, completed and init, other values return error condition.
 // The expected value for "ready" is two digits, ready and total number of containers, which are separated by a "/" character.
 function getIconForPodStatus(status: string, ready: string): vscode.Uri {
-    console.log(status);
     if (status === "running") {
         const readyFields = ready.split("/", 2);
         if (readyFields[0] === readyFields[1]) {

--- a/src/components/clusterexplorer/resourcekinds/resourcekind.pod.ts
+++ b/src/components/clusterexplorer/resourcekinds/resourcekind.pod.ts
@@ -18,7 +18,11 @@ export const podUICustomiser = {
     }
 };
 
+// getIconForPodStatus takes status and ready values and returns an appropriate icon uri
+// Currently, supported/expected status values are running and complete, others return error condition.
+// The expected value for "ready" is two digits, ready and total number of containers, which are separated by a "/" character.
 function getIconForPodStatus(status: string, ready: string): vscode.Uri {
+    console.log(status);
     if (status === "running") {
         const readyFields = ready.split("/", 2);
         if (readyFields[0] === readyFields[1]) {
@@ -28,6 +32,8 @@ function getIconForPodStatus(status: string, ready: string): vscode.Uri {
         }
     } else if (status === "completed") {
         return assetUri("images/completedPod.svg");
+    } else if (status.startsWith("init")) {
+        return assetUri("images/notReadyPod.svg");
     } else {
         return assetUri("images/errorPod.svg");
     }

--- a/src/components/kubectl/logs.ts
+++ b/src/components/kubectl/logs.ts
@@ -104,7 +104,7 @@ export async function getLogsForContainer(
     }
 
     if (containerName) {
-        args.push(`--container=${containerName}`);
+        args.push(`--container=${containerName.trim()}`);
     }
 
     if (displayMode === LogsDisplayMode.Follow) {

--- a/src/components/logs/app/main.js
+++ b/src/components/logs/app/main.js
@@ -36,7 +36,8 @@ window.addEventListener('message', (event) => {
             select.setAttribute('id', 'containers-select');
             // eslint-disable-next-line @typescript-eslint/prefer-for-of
             for (let i = 0; i < containers.length; i += 1) {
-                const option = createElement('vscode-option', containers[i], containers[i]);
+                const option = createElement('vscode-option', containers[i].name,
+                    (containers[i].initContainer ? containers[i].name + ' (init)' : containers[i].name));
                 if (i === 0) {
                     option.setAttribute('selected', '');
                 }

--- a/src/components/logs/logsWebview.ts
+++ b/src/components/logs/logsWebview.ts
@@ -100,7 +100,7 @@ export class LogsPanel extends WebPanel {
     private setContainers(containers: Container[]) {
         this.panel.webview.postMessage({
             command: 'init',
-            containers: containers.map((container) => container.name),
+            containers: containers,
             colors: this.getColors()
         });
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1194,31 +1194,6 @@ function parseName(line: string): string {
     return line.split(' ')[0];
 }
 
-async function getContainers(resource: ContainerContainer): Promise<Container[] | undefined> {
-    const q = shell.isWindows() ? `'` : `"`;
-    const lit = (l: string) => `{${q}${l}${q}}`;
-    const query = `${lit("NAME\\tIMAGE\\n")}{range ${resource.containersQueryPath}.initContainers[*]}{.name}\
-    ${lit("\\t")}{.image}${lit("\\n")}{end}{range ${resource.containersQueryPath}.containers[*]}{.name}\
-    ${lit("\\t")}{.image}${lit("\\n")}{end}`;
-    const queryArg = shell.isWindows() ? `"${query}"` : `'${query}'`;
-    let cmd = `get ${resource.kindName} -o jsonpath=${queryArg}`;
-    if (resource.namespace && resource.namespace.length > 0) {
-        cmd += ' --namespace=' + resource.namespace;
-    }
-    const containers = await kubectl.asLines(cmd);
-    if (failed(containers)) {
-        vscode.window.showErrorMessage("Failed to get containers in resource: " + containers.error[0]);
-        return undefined;
-    }
-
-    const containersEx = containers.result.map((s) => {
-        const bits = s.split('\t');
-        return { name: bits[0], image: bits[1] };
-    });
-
-    return containersEx;
-}
-
 enum PodSelectionFallback {
     None,
     AnyPod,
@@ -1379,6 +1354,46 @@ async function selectContainerForResource(resource: ContainerContainer): Promise
     }
 
     return value.container;
+}
+
+async function getContainers(resource: ContainerContainer): Promise<Container[] | undefined> {
+
+    const containersEx: Container[] = [];
+
+    const initContainers = await getContainerQuery(resource, 'initContainers');
+    if (initContainers) {
+        initContainers.map((s) => { containersEx.push(s)});
+    }
+    const containers = await getContainerQuery(resource, 'containers');
+    if (containers) {
+        containers.map((s) => { containersEx.push(s)});
+    }
+    if (containersEx.length) {
+        return containersEx;
+    }
+    return undefined;
+}
+
+async function getContainerQuery(resource: ContainerContainer, containerType: string): Promise<Container[] | undefined> {
+    const q = shell.isWindows() ? `'` : `"`;
+    const lit = (l: string) => `{${q}${l}${q}}`;
+    const query = `${lit("NAME\\tIMAGE\\n")}\
+    {range ${resource.containersQueryPath}.${containerType}[*]}{.name}${lit("\\t")}{.image}${lit("\\n")}{end}`;
+    const queryArg = shell.isWindows() ? `"${query}"` : `'${query}'`;
+    let cmd = `get ${resource.kindName} -o jsonpath=${queryArg}`;
+    if (resource.namespace && resource.namespace.length > 0) {
+        cmd += ' --namespace=' + resource.namespace;
+    }
+    const c = await kubectl.asLines(cmd);
+    if (failed(c)) {
+        vscode.window.showErrorMessage("Failed to get containers in resource: " + c.error[0]);
+        return undefined;
+    }
+    const containersEx = c.result.map((s) => {
+        const bits = s.split('\t');
+        return { name: bits[0], image: bits[1], initContainer: containerType === 'initContainers'};
+    });
+    return containersEx;
 }
 
 export async function getContainersForResource(resource: ContainerContainer): Promise<Container[] | null> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1918,6 +1918,7 @@ const waitForRunningPod = (name: string, callback: () => void) => {
             if (!succ) {
                 return;
             }
+
             if (succ.stdout === 'Running') {
                 callback();
                 return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1197,7 +1197,9 @@ function parseName(line: string): string {
 async function getContainers(resource: ContainerContainer): Promise<Container[] | undefined> {
     const q = shell.isWindows() ? `'` : `"`;
     const lit = (l: string) => `{${q}${l}${q}}`;
-    const query = `${lit("NAME\\tIMAGE\\n")}{range ${resource.containersQueryPath}.containers[*]}{.name}${lit("\\t")}{.image}${lit("\\n")}{end}`;
+    const query = `${lit("NAME\\tIMAGE\\n")}{range ${resource.containersQueryPath}.initContainers[*]}{.name}\
+    ${lit("\\t")}{.image}${lit("\\n")}{end}{range ${resource.containersQueryPath}.containers[*]}{.name}\
+    ${lit("\\t")}{.image}${lit("\\n")}{end}`;
     const queryArg = shell.isWindows() ? `"${query}"` : `'${query}'`;
     let cmd = `get ${resource.kindName} -o jsonpath=${queryArg}`;
     if (resource.namespace && resource.namespace.length > 0) {
@@ -1901,7 +1903,6 @@ const waitForRunningPod = (name: string, callback: () => void) => {
             if (!succ) {
                 return;
             }
-
             if (succ.stdout === 'Running') {
                 callback();
                 return;

--- a/src/kubectlUtils.ts
+++ b/src/kubectlUtils.ts
@@ -447,6 +447,8 @@ export async function waitForRunningPod(kubectl: Kubectl, podName: string): Prom
         kubeChannel.showOutput(`pod/${podName} status: ${status}`);
         if (status === "Running") {
             return;
+        } else if (status.startsWith("Init")) {
+            return;
         } else if (!isTransientPodState(status)) {
             const logsResult = await kubectl.invokeCommand(`logs pod/${podName}`);
             kubeChannel.showOutput(`Failed to start the pod "${podName}". Its status is "${status}".

--- a/src/kubectlUtils.ts
+++ b/src/kubectlUtils.ts
@@ -447,8 +447,6 @@ export async function waitForRunningPod(kubectl: Kubectl, podName: string): Prom
         kubeChannel.showOutput(`pod/${podName} status: ${status}`);
         if (status === "Running") {
             return;
-        } else if (status.startsWith("Init")) {
-            return;
         } else if (!isTransientPodState(status)) {
             const logsResult = await kubectl.invokeCommand(`logs pod/${podName}`);
             kubeChannel.showOutput(`Failed to start the pod "${podName}". Its status is "${status}".
@@ -461,7 +459,7 @@ export async function waitForRunningPod(kubectl: Kubectl, podName: string): Prom
 }
 
 function isTransientPodState(status: string): boolean {
-    return status === "ContainerCreating" || status === "Pending" || status === "Succeeded";
+    return status === "ContainerCreating" || status === "Pending" || status === "Succeeded" || status.startsWith("Init");
 }
 
 /**

--- a/src/kuberesources.objectmodel.ts
+++ b/src/kuberesources.objectmodel.ts
@@ -38,6 +38,7 @@ export interface Container {
     readonly name: string;
     readonly image: string;
     readonly livenessProbe?: LivenessProbe;
+    readonly initContainer: boolean;
 }
 
 export interface Pod extends KubernetesResource {


### PR DESCRIPTION
I have a need to see the logs for initContainers while running and after they have completed.  This also makes the pod status color yellow for notReady while the initContainer is running as opposed to red which may make the user think there's an error condition.