### PR TITLE
Migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/schema/swagger-v1.12.2.json
+++ b/schema/swagger-v1.12.2.json
@@ -2984,7 +2984,7 @@
                         "type": "string"
                     },
                     "type": "array",
-                    "description": "Names by which this image is known. e.g. [\"k8s.gcr.io/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]"
+                    "description": "Names by which this image is known. e.g. [\"registry.k8s.io/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]"
                 }
             }
         },

--- a/snippets/statefulset.yaml
+++ b/snippets/statefulset.yaml
@@ -20,7 +20,7 @@ body: |2
       spec:
         containers:
         - name: ${2:myapp}
-          image: k8s.gcr.io/nginx-slim:0.8
+          image: registry.k8s.io/nginx-slim:0.8
           ports:
           - containerPort: 80
             name: web


### PR DESCRIPTION
This PR does the following changes:
- modify all occurrences of k8s.gcr.io to registry.k8s.io.

This is a part of https://github.com/kubernetes/k8s.io/issues/4780.