### PR TITLE
Fix/cluster tree label issue

### DIFF
--- a/src/components/clusterexplorer/node.resource.ts
+++ b/src/components/clusterexplorer/node.resource.ts
@@ -46,9 +46,9 @@ export class ResourceNode extends ClusterExplorerNodeImpl implements ClusterExpl
             arguments: [this]
         };
         treeItem.contextValue = `vsKubernetes.resource.${this.kind.abbreviation}`;
-        if (this.namespace) {
-            treeItem.tooltip = `Namespace: ${this.namespace}`; // TODO: show only if in non-current namespace?
-        }
+
+        treeItem.tooltip = `${this.kind.label}: ${this.name}`;
+
         const uiCustomiser = getUICustomiser(this.kind);
         uiCustomiser.customiseTreeItem(this, treeItem);
         return treeItem;


### PR DESCRIPTION
HIya, this PR is intending to cater minor UI labelling issue which is actually a `tooltip` via `tree item` the NVDA reads the correct data, please refer to the issue - #1158 

Thank you so much and fyi: @lstocchi , @itowlson and @squillace ❤️☕️🙏 

Please recommend if the original behaviour was expected otherwise we can adapt to this one.

**Previously:** 

<img width="356" alt="Screenshot 2023-03-21 at 7 50 49 PM" src="https://user-images.githubusercontent.com/6233295/226536205-98a5212b-1d40-4c14-bf40-ebda71bfd9b6.png">

<img width="374" alt="Screenshot 2023-03-21 at 7 51 18 PM" src="https://user-images.githubusercontent.com/6233295/226536233-46ca9521-df70-4b55-900a-a5bd92777902.png">


**Fix reads the correct tool tip.**

<img width="467" alt="Screenshot 2023-03-21 at 7 47 12 PM" src="https://user-images.githubusercontent.com/6233295/226536303-bff81b5f-6a15-42cf-9c73-4a5e1e4c3559.png">

<img width="372" alt="Screenshot 2023-03-21 at 7 46 55 PM" src="https://user-images.githubusercontent.com/6233295/226536335-7307d452-fe8d-44a6-ae49-b2fc704a7fd7.png">

<img width="500" alt="Screenshot 2023-03-21 at 7 46 46 PM" src="https://user-images.githubusercontent.com/6233295/226536375-a47f4ad9-6aa0-435b-9d82-f8b1f8c506c4.png">



