### PR TITLE
fix: handle ANSI color codes in log webview (#1164)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@kubernetes/client-node": "^0.14.0",
                 "ajv": "^6.9.1",
+                "ansi-to-html": "^0.7.2",
                 "await-notify": "^1.0.1",
                 "clipboardy": "^1.2.3",
                 "compare-versions": "^3.1.0",
@@ -1843,6 +1844,20 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/ansi-to-html": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.7.2.tgz",
+            "integrity": "sha512-v6MqmEpNlxF+POuyhKkidusCHWWkaLcGRURzivcU3I9tv7k4JVhFcnukrM5Rlk2rUywdZuzYAZ+kbZqWCnfN3g==",
+            "dependencies": {
+                "entities": "^2.2.0"
+            },
+            "bin": {
+                "ansi-to-html": "bin/ansi-to-html"
+            },
+            "engines": {
+                "node": ">=8.0.0"
             }
         },
         "node_modules/ansi-wrap": {
@@ -4069,8 +4084,7 @@
         "node_modules/entities": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-            "dev": true
+            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
         },
         "node_modules/env-paths": {
             "version": "2.2.1",
@@ -15468,6 +15482,14 @@
                 "color-convert": "^1.9.0"
             }
         },
+        "ansi-to-html": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.7.2.tgz",
+            "integrity": "sha512-v6MqmEpNlxF+POuyhKkidusCHWWkaLcGRURzivcU3I9tv7k4JVhFcnukrM5Rlk2rUywdZuzYAZ+kbZqWCnfN3g==",
+            "requires": {
+                "entities": "^2.2.0"
+            }
+        },
         "ansi-wrap": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
@@ -17401,8 +17423,7 @@
         "entities": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-            "dev": true
+            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
         },
         "env-paths": {
             "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -1301,6 +1301,7 @@
     "dependencies": {
         "@kubernetes/client-node": "^0.14.0",
         "ajv": "^6.9.1",
+        "ansi-to-html": "^0.7.2",
         "await-notify": "^1.0.1",
         "clipboardy": "^1.2.3",
         "compare-versions": "^3.1.0",

--- a/src/components/logs/app/index.html
+++ b/src/components/logs/app/index.html
@@ -174,5 +174,12 @@
             <a id="bottom"></a>
         </div>
     </div>
+    <script type="importmap">
+        {
+           "imports": {,
+              "ansiToHtml": "${ansiToHtml}",
+           }
+        }
+     </script>
     </body>
 </html>

--- a/src/components/logs/app/main.js
+++ b/src/components/logs/app/main.js
@@ -1,4 +1,6 @@
 const vscode = acquireVsCodeApi();
+const Convert = require('ansi-to-html');
+const convert = new Convert();
 
 const CHRONO_UNITS = [
     { symbol: 'h', seconds: 3600 },
@@ -562,6 +564,7 @@ function highlightWords(row) {
         return row;
     }
 
+    row = convert.toHtml(row);
     for (const rule of schemaColors) {
         const regexp = new RegExp(rule.regex, "gi");
         if (regexp.test(row)) {

--- a/src/components/logs/logsWebview.ts
+++ b/src/components/logs/logsWebview.ts
@@ -150,6 +150,11 @@ export class LogsPanel extends WebPanel {
             path.join(logViewAppRootOnDisk, 'webviewElements.js')
         );
         const webviewElementsSrc = this.panel.webview.asWebviewUri(webviewElementsPath);
+
+        const ansiToHtmlElementsPath = vscode.Uri.file(
+            path.join(logViewAppRootOnDisk, 'ansiToHtml.js')
+        );
+        const ansiToHtmlElementsSrc = this.panel.webview.asWebviewUri(ansiToHtmlElementsPath);
         const htmlString: string = fs.readFileSync(path.join(logViewAppRootOnDisk, 'index.html'), 'utf8');
         const meta = `<meta http-equiv="Content-Security-Policy"
         content="connect-src *;
@@ -160,6 +165,7 @@ export class LogsPanel extends WebPanel {
         return `${htmlString}`
             .replace('index.js', `${logIndexJSSrc}`)
             .replace('webviewElements.js', `${webviewElementsSrc}`)
+            .replace('${ansiToHtml}', `${ansiToHtmlElementsSrc}`)
             .replace('<!-- meta http-equiv="Content-Security-Policy" -->', meta);
     }
 

--- a/src/components/logs/webpack.config.js
+++ b/src/components/logs/webpack.config.js
@@ -5,10 +5,13 @@ const HtmlWebPackPlugin = require( 'html-webpack-plugin' );
 
 module.exports = {
   entry: {
+    ansiToHtml: [
+      "./node_modules/ansi-to-html/lib/ansi_to_html.js"
+    ],
     index: "./src/components/logs/app/main.js",
     webviewElements: [
       "./node_modules/@bendera/vscode-webview-elements/dist/bundled.js"
-    ]
+    ],
   },
   output: {
     path: path.resolve(__dirname, '..', '..', '..', 'dist', 'logView')


### PR DESCRIPTION
it fixes #1164 

Before:
```
2023-04-01T04:52:58.680172511Z �[40m�[32minfo�[39m�[22m�[49m: Microsoft.Hosting.Lifetime[14]
2023-04-01T04:52:58.680215693Z       Now listening on: http://[::]:80
2023-04-01T04:52:58.681332023Z �[40m�[32minfo�[39m�[22m�[49m: Microsoft.Hosting.Lifetime[0]
2023-04-01T04:52:58.681361839Z       Application started. Press Ctrl+C to shut down.
2023-04-01T04:52:58.681947171Z �[40m�[32minfo�[39m�[22m�[49m: Microsoft.Hosting.Lifetime[0]
2023-04-01T04:52:58.681956207Z       Hosting environment: Production
2023-04-01T04:52:58.681959132Z �[40m�[32minfo�[39m�[22m�[49m: Microsoft.Hosting.Lifetime[0]
2023-04-01T04:52:58.681961888Z       Content root path: /app/
```

After:
![image](https://user-images.githubusercontent.com/49404737/233854639-6b95bc37-2210-41ba-aca2-6c7e03c5fcf8.png)

