### PR TITLE
feat: handle predefined vscode variables in extension setting (#940)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Minikube tools to be installed and available on your PATH.
 
 ## Extension Settings
 
-  The Kubernetes extension supports variable substitution for the set of settings that requires a path as value. Variable substitution is supported using `${variableName}` syntax. A list of the supported variables can be found at [variables-reference](https://code.visualstudio.com/docs/editor/variables-reference).
+  The Kubernetes extension enables variable substitution for settings that require a path as a value. Variable substitution can be done using the `${variableName}` syntax. You can find a list of the variables supported in the [variables-reference](https://code.visualstudio.com/docs/editor/variables-reference) documentation.
 
    * `vs-kubernetes` - Parent for Kubernetes-related extension settings
        * `vs-kubernetes.namespace` - The namespace to use for all commands

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ Minikube tools to be installed and available on your PATH.
 
 ## Extension Settings
 
+  The Kubernetes extension supports variable substitution for the set of settings that requires a path as value. Variable substitution is supported using `${variableName}` syntax. A list of the supported variables can be found at [variables-reference](https://code.visualstudio.com/docs/editor/variables-reference).
+
    * `vs-kubernetes` - Parent for Kubernetes-related extension settings
        * `vs-kubernetes.namespace` - The namespace to use for all commands
        * `vs-kubernetes.kubectl-path` - File path to the kubectl binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.

--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -3,6 +3,7 @@ import { Host } from '../../host';
 import { Shell, Platform } from '../../shell';
 import { Dictionary } from '../../utils/dictionary';
 import { getCacheExpirationDate } from '../clusterprovider/common/cacheinfo';
+import { interpolateVariables } from '../../utils/interpolation';
 
 const EXTENSION_CONFIG_KEY = "vs-kubernetes";
 const KUBECONFIG_PATH_KEY = "vs-kubernetes.kubeconfig";
@@ -80,6 +81,10 @@ export function getKnownKubeconfigs(): string[] {
     if (!kkcConfig || !kkcConfig.length) {
         return [];
     }
+    (kkcConfig as string[]).forEach((value, index) => {
+        const interpolatedValue = interpolateVariables(value);
+        kkcConfig[index] = interpolatedValue;
+    });
     return kkcConfig as string[];
 }
 
@@ -93,8 +98,8 @@ export async function setActiveKubeconfig(kubeconfig: string): Promise<void> {
     await addPathToConfig(KUBECONFIG_PATH_KEY, kubeconfig);
 }
 
-export function getActiveKubeconfig(): string {
-    return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)[KUBECONFIG_PATH_KEY];
+export function getActiveKubeconfig(): string | undefined {
+    return interpolateVariables(vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)[KUBECONFIG_PATH_KEY]);
 }
 
 // Functions for working with tool paths
@@ -136,7 +141,7 @@ export function getToolPath(_host: Host, shell: Shell, tool: string): string | u
         userValues[baseKey] ||
         defaultValues[baseKey];
 
-    return topLevelToolPath || globalBackCompatSetting;
+    return interpolateVariables(topLevelToolPath || globalBackCompatSetting);
 }
 
 export function toolPathOSKey(os: Platform, tool: string): string {
@@ -232,8 +237,8 @@ export function getNodejsAutoDetectRemoteRoot(): boolean {
     return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.nodejs-autodetect-remote-root'];
 }
 // user specified root location of the source code in the container
-export function getNodejsRemoteRoot(): string {
-    return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.nodejs-remote-root'];
+export function getNodejsRemoteRoot(): string | undefined {
+    return interpolateVariables(vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.nodejs-remote-root']);
 }
 // remote debugging port for nodejs. Usually 9229
 export function getNodejsDebugPort(): number | undefined {
@@ -253,8 +258,8 @@ export function getPythonAutoDetectRemoteRoot(): boolean {
 }
 
 // user specified root location of the source code in the container
-export function getPythonRemoteRoot(): string {
-    return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.python-remote-root'];
+export function getPythonRemoteRoot(): string | undefined {
+    return interpolateVariables(vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.python-remote-root']);
 }
 
 // remote debugging port for Python. Usually 5678
@@ -263,8 +268,8 @@ export function getPythonDebugPort(): number | undefined {
 }
 
 // remote debugging path to dotnet debugger (vsdbg)
-export function getDotnetVsdbgPath(): string {
-    return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.dotnet-vsdbg-path'];
+export function getDotnetVsdbgPath(): string | undefined {
+    return interpolateVariables(vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.dotnet-vsdbg-path']);
 }
 
 // remote debugging sourceFileMap for dotnet. An entry "sourceFileMap": {"<vs-kubernetes.dotnet-source-file-map>":"$workspaceFolder"} will be added to the debug configuration

--- a/src/debug/debugSession.ts
+++ b/src/debug/debugSession.ts
@@ -22,6 +22,7 @@ import { Dictionary } from "../utils/dictionary";
 import { definedOf } from "../utils/array";
 import * as imageUtils from "../image/imageUtils";
 import { ExecResult } from "../binutilplusplus";
+import { interpolateVariables } from "../utils/interpolation";
 
 const debugCommandDocumentationUrl = "https://github.com/Azure/vscode-kubernetes-tools/blob/master/debug-on-kubernetes.md";
 
@@ -73,7 +74,7 @@ export class DebugSession implements IDebugSession {
         }
 
         const cwd = workspaceFolder.uri.fsPath;
-        const imagePrefix = vscode.workspace.getConfiguration().get<string | null>("vsdocker.imageUser", null);
+        const imagePrefix = interpolateVariables(vscode.workspace.getConfiguration().get("vsdocker.imageUser", undefined));
         const containerEnv = Dictionary.of<string>();
         const portInfo = await this.debugProvider.resolvePortsFromFile(dockerfile, containerEnv);
         const debugArgs = await this.debugProvider.getDebugArgs();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -88,6 +88,7 @@ import { getCurrentContext } from './kubectlUtils';
 import { LocalTunnelDebugger } from './components/localtunneldebugger/localtunneldebugger';
 import { setAssetContext } from './assets';
 import { fixOldInstalledBinaryPermissions } from './components/installer/fixwriteablebinaries';
+import { interpolateVariables } from './utils/interpolation';
 
 let explainActive = false;
 let swaggerSpecPromise: Promise<explainer.SwaggerModel | undefined> | null = null;
@@ -915,7 +916,7 @@ function findNameAndImageInternal(fn: (name: string, image: string) => void) {
     const name = docker.sanitiseTag(folderName);
     findVersion().then((version) => {
         let image = `${name}:${version}`;
-        const user = vscode.workspace.getConfiguration().get("vsdocker.imageUser", null);
+        const user = interpolateVariables(vscode.workspace.getConfiguration().get("vsdocker.imageUser", undefined));
         if (user) {
             image = `${user}/${image}`;
         }
@@ -969,7 +970,7 @@ function runKubernetes() {
 
 function diagnosePushError(_exitCode: number, error: string): string {
     if (error.includes("denied")) {
-        const user = vscode.workspace.getConfiguration().get("vsdocker.imageUser", null);
+        const user = interpolateVariables(vscode.workspace.getConfiguration().get("vsdocker.imageUser", undefined));
         if (user) {
             return "Failed pushing the image to remote registry. Try to login to an image registry.";
         } else {

--- a/src/utils/interpolation.ts
+++ b/src/utils/interpolation.ts
@@ -1,0 +1,82 @@
+/* 
+*  This file is based on the work made by DominicVonk at https://github.com/DominicVonk/vscode-variables
+*  This has been imported and updated to allow using the latest @types/vscode library
+*/
+import * as vscode from 'vscode';
+import * as process from 'process';
+import * as path from 'path';
+
+export function interpolateVariables(value: string | undefined, recursive = false): string | undefined {
+    if (!value) {
+        return value;
+    }
+
+    const workspaces = vscode.workspace.workspaceFolders;
+    const workspace = workspaces ? workspaces[0] : undefined;
+    const activeFile = vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document : undefined; // TODO: upgrade TypeScript so we can use ?.
+    const absoluteFilePath = activeFile ? activeFile.uri ? activeFile.uri.fsPath : undefined : undefined;  // TODO: upgrade TypeScript so we can use ?.
+
+    if (workspace) {
+        value = value.replace(/\${workspaceFolder}/g, workspace.uri.fsPath);
+        value = value.replace(/\${workspaceFolderBasename}/g, workspace.name);
+    }
+        
+    let fileWorkspace = workspace;
+    let relativeFilePath = absoluteFilePath;
+    if (workspaces) {
+        for (let inner_workspace of workspaces) {
+            if (absoluteFilePath && absoluteFilePath.replace(inner_workspace.uri.fsPath, '') !== absoluteFilePath) {
+                fileWorkspace = inner_workspace;
+                relativeFilePath = absoluteFilePath.replace(inner_workspace.uri.fsPath, '').substring(path.sep.length);
+                break;
+            }
+        }
+    }
+    
+    if (fileWorkspace) {
+        value = value.replace(/\${fileWorkspaceFolder}/g, fileWorkspace.uri.fsPath);
+    }    
+
+    if (relativeFilePath) {
+        value = value.replace(/\${relativeFile}/g, relativeFilePath);
+        value = value.replace(/\${relativeFileDirname}/g, relativeFilePath.substring(0, relativeFilePath.lastIndexOf(path.sep)));
+    }    
+
+    if (absoluteFilePath) {
+        const parsedPath = path.parse(absoluteFilePath);
+        value = value.replace(/\${file}/g, absoluteFilePath);
+        value = value.replace(/\${fileBasename}/g, parsedPath.base);
+        value = value.replace(/\${fileBasenameNoExtension}/g, parsedPath.name);
+        value = value.replace(/\${fileExtname}/g, parsedPath.ext);
+        value = value.replace(/\${fileDirname}/g, parsedPath.dir.substr(parsedPath.dir.lastIndexOf(path.sep) + 1));
+        value = value.replace(/\${cwd}/g, parsedPath.dir);
+    }
+    
+    value = value.replace(/\${pathSeparator}/g, path.sep);
+
+    const activeEditor = vscode.window.activeTextEditor;
+    if (activeEditor) {
+        value = value.replace(/\${lineNumber}/g, (activeEditor.selection.start.line + 1).toString());
+        value = value.replace(/\${selectedText}/g, activeEditor.document.getText(new vscode.Range(activeEditor.selection.start, activeEditor.selection.end)));
+    }
+    
+    value = value.replace(/\${env:(.*?)}/g, function (variable) {
+        const matches = variable.match(/\${env:(.*?)}/);
+        if (matches && matches.length > 1) {
+            return process.env[matches[1]] || '';
+        }
+        return '';
+    });
+    value = value.replace(/\${config:(.*?)}/g, function (variable) {
+        const matches = variable.match(/\${env:(.*?)}/);
+        if (matches && matches.length > 1) {
+            return vscode.workspace.getConfiguration().get(matches[1], '');
+        }
+        return '';
+    });
+
+    if (recursive && value.match(/\${(workspaceFolder|workspaceFolderBasename|fileWorkspaceFolder|relativeFile|fileBasename|fileBasenameNoExtension|fileExtname|fileDirname|cwd|pathSeparator|lineNumber|selectedText|env:(.*?)|config:(.*?))}/)) {
+        value = interpolateVariables(value, recursive);
+    }
+    return value;
+}

--- a/src/utils/interpolation.ts
+++ b/src/utils/interpolation.ts
@@ -5,6 +5,7 @@
 import * as vscode from 'vscode';
 import * as process from 'process';
 import * as path from 'path';
+import { homedir } from 'os';
 
 export function interpolateVariables(value: string | undefined, recursive = false): string | undefined {
     if (!value) {
@@ -15,6 +16,8 @@ export function interpolateVariables(value: string | undefined, recursive = fals
     const workspace = workspaces ? workspaces[0] : undefined;
     const activeFile = vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document : undefined; // TODO: upgrade TypeScript so we can use ?.
     const absoluteFilePath = activeFile ? activeFile.uri ? activeFile.uri.fsPath : undefined : undefined;  // TODO: upgrade TypeScript so we can use ?.
+
+    value = value.replace(/\${userHome}/g, homedir());
 
     if (workspace) {
         value = value.replace(/\${workspaceFolder}/g, workspace.uri.fsPath);
@@ -48,7 +51,7 @@ export function interpolateVariables(value: string | undefined, recursive = fals
         value = value.replace(/\${fileBasename}/g, parsedPath.base);
         value = value.replace(/\${fileBasenameNoExtension}/g, parsedPath.name);
         value = value.replace(/\${fileExtname}/g, parsedPath.ext);
-        value = value.replace(/\${fileDirname}/g, parsedPath.dir.substr(parsedPath.dir.lastIndexOf(path.sep) + 1));
+        value = value.replace(/\${fileDirname}/g, parsedPath.dir.substring(parsedPath.dir.lastIndexOf(path.sep) + 1));
         value = value.replace(/\${cwd}/g, parsedPath.dir);
     }
     

--- a/src/utils/interpolation.ts
+++ b/src/utils/interpolation.ts
@@ -7,6 +7,28 @@ import * as process from 'process';
 import * as path from 'path';
 import { homedir } from 'os';
 
+/**
+ * It substitutes variables that use the syntax ${variableName} and belong to the list below, within the value.
+ * If recursive is true, the function is called recursively if another variable is found after the first call.
+ * E.g "${userHome}/my_custom_kubectl_folder/kubectl" -> "home_path/my_custom_kubectl_folder/kubectl"
+ * 
+ * The following predefined variables are supported:
+ *      ${userHome} - the path of the user's home folder
+ *      ${workspaceFolder} - the path of the folder opened in VS Code
+ *      ${workspaceFolderBasename} - the name of the folder opened in VS Code without any slashes (/)
+ *      ${file} - the current opened file
+ *      ${fileWorkspaceFolder} - the current opened file's workspace folder
+ *      ${relativeFile} - the current opened file relative to workspaceFolder
+ *      ${relativeFileDirname} - the current opened file's dirname relative to workspaceFolder
+ *      ${fileBasename} - the current opened file's basename
+ *      ${fileBasenameNoExtension} - the current opened file's basename with no file extension
+ *      ${fileExtname} - the current opened file's extension
+ *      ${fileDirname} - the current opened file's folder path
+ *      ${cwd} - the task runner's current working directory upon the startup of VS Code
+ *      ${lineNumber} - the current selected line number in the active file
+ *      ${selectedText} - the current selected text in the active file
+ *      ${pathSeparator} - the character used by the operating system to separate components in file paths
+ */
 export function interpolateVariables(value: string | undefined, recursive = false): string | undefined {
     if (!value) {
         return value;

--- a/test/suite/utils/interpolation.test.ts
+++ b/test/suite/utils/interpolation.test.ts
@@ -1,0 +1,35 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as os from 'os';
+import { interpolateVariables } from "../../../src/utils/interpolation";
+import * as vscode from 'vscode';
+
+suite("Interpolate Vscode variables", () => {
+    test("return empty string if trying to interpolate empty string", () => {
+        const result = interpolateVariables("");
+        assert.strictEqual(result, "");
+    });
+
+    test("return undefined value if trying to interpolate an undefined value", () => {
+        const result = interpolateVariables(undefined);
+        assert.strictEqual(result, undefined);
+    });
+
+    test("replace userHome variable with actual home dir value", () => {
+        sinon.stub(os, "homedir").returns('home');
+        const result = interpolateVariables("${userHome}/folder");
+        assert.strictEqual(result, "home/folder");
+    });
+
+    test("replace workspaceFolder variable with actual workspaceFolder path", () => {
+        const workspaceFolder: vscode.WorkspaceFolder = {
+            uri: vscode.Uri.parse("workspace_path"),
+            name: '',
+            index: 0
+        }
+        sinon.stub(vscode.workspace, "workspaceFolders").value([workspaceFolder]);
+        const result = interpolateVariables("${workspaceFolder}/file");
+        sinon.assert.match(result && result.includes("workspace_path/file"), true);
+    });
+
+});


### PR DESCRIPTION
This PR allows to handle a set of vscode predefined variables when used as values in the extension settings  -> https://code.visualstudio.com/docs/editor/variables-reference

This should resolve https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/940 and https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1141

Now the user could write a setting like 
```
"vscode-kubernetes.kubectl-path": "${userHome}/my_custom_kubectl_folder/kubectl"
```

The interpolation function has been taken from https://github.com/DominicVonk/vscode-variables and updated. The license allowed it.
I couldn't import the library as it was very old and not maintained apparently. It relies on the old vscode dependency which break this one when imported (the k8s-tools depends on the new `@types/vscode` and `vscode-test`)