### PR TITLE
fix: retrieve tool paths outside kubernetes object and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,9 +186,9 @@ Minikube tools to be installed and available on your PATH.
 
    * `vs-kubernetes` - Parent for Kubernetes-related extension settings
        * `vs-kubernetes.namespace` - The namespace to use for all commands
-       * `vs-kubernetes.kubectl-path` - File path to the kubectl binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
-       * `vs-kubernetes.helm-path` - File path to the helm binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
-       * `vs-kubernetes.minikube-path` - File path to the minikube binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
+       * `vs-kubernetes.kubectl-path` (*deprecated*) - File path to the kubectl binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension. This is deprecated, please use `vscode-kubernetes.kubectl-path` instead.
+       * `vs-kubernetes.helm-path` (*deprecated*) - File path to the helm binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension. This is deprecated, please use `vscode-kubernetes.helm-path` instead.
+       * `vs-kubernetes.minikube-path` (*deprecated*) - File path to the minikube binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension. This is deprecated, please use `vscode-kubernetes.minikube-path` instead.
        * `vs-kubernetes.kubectlVersioning` - By default, the extension uses the `kubectl` binary you provide on the system PATH or in the `vs-kubernetes.kubectl-path` configuration setting. If you set this setting to `infer`, then for each cluster the extension will attempt to identify the cluster version and download a compatible `kubectl` binary.  This improves compatibility if you have multiple Kubernetes versions in play, but may be slower.  **Note:** this setting is checked only when the extension loads; if you change it, you must reload the extension.
        * `vs-kubernetes.kubeconfig` - File path to the kubeconfig file you want to use. This overrides both the default kubeconfig and the KUBECONFIG environment variable.
        * `vs-kubernetes.knownKubeconfigs` - An array of file paths of kubeconfig files that you want to be able to quickly switch between using the Set Kubeconfig command.
@@ -206,6 +206,9 @@ Minikube tools to be installed and available on your PATH.
    * `checkForMinikubeUpgrade` - On extension startup, notify if a minikube upgrade is available. Defaults to true.
    * `disable-lint` - Disable all linting of Kubernetes files
    * `disable-linters` - Disable specific linters by name
+   * `vscode-kubernetes.kubectl-path` - File path to the kubectl binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
+   * `vscode-kubernetes.helm-path` - File path to the helm binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
+   * `vscode-kubernetes.minikube-path` - File path to the minikube binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
    * `vscode-kubernetes.log-viewer.follow` - Set to true to follow logs by default in the log viewer.
    * `vscode-kubernetes.log-viewer.timestamp` - Set to true to show timestamps by default in the log viewer.
    * `vscode-kubernetes.log-viewer.since` - How far back to fetch logs from in seconds by default. Set to -1 for all logs.

--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -133,8 +133,10 @@ export function getToolPath(_host: Host, shell: Shell, tool: string): string | u
     const topLevelToolPath =
         userValues[osKey] ||
         defaultValues[osKey] ||
+        config.get(osKey) ||
         userValues[baseKey] ||
         defaultValues[baseKey];
+        config.get(baseKey);
 
     return topLevelToolPath || globalBackCompatSetting;
 }


### PR DESCRIPTION
This PR fixes an issue when retrieving the new tool path settings https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/pull/892. The extension only looks for them within the `vs-kubernetes` object but this is not the default, so we should look for them inside the config file.

I also updated the doc to reflect the new settings and mark as deprecated the older ones. It fixes #1174 