### PR TITLE
fix: detect errors in yaml file before actually parse it with node-yaml-parser lib (#1170)

### DIFF
--- a/src/yaml-support/yaml-locator.ts
+++ b/src/yaml-support/yaml-locator.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 import { parse, findNodeAtPosition } from 'node-yaml-parser';
+import YAML = require('yamljs');
 
 export function isMapping(node: YamlNode): node is YamlMap {
     return node.kind === 'MAPPING';
@@ -110,6 +111,7 @@ export class YamlLocator {
             // the document and line lengths from parse method is cached into YamlCachedDocuments to avoid duplicate
             // parse against the same text.
             try {
+                YAML.parse(textDocument.getText()); // this is used to detect errors in the yaml file before actually parse it with the node-yaml-parser lib
                 const { documents, lineLengths } = parse(textDocument.getText());
                 this.cache[key].yamlDocs = documents;
                 this.cache[key].lineLengths = lineLengths;


### PR DESCRIPTION
After digging a bit i found out that the node-yaml-parser is responsible of the memory leaks detected in https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1170 . If the yaml file is not formatted correctly it start looping in a while and never ends.

It would be great to have this fixed in the lib itself but it seems an abandoned project. I opened an issue 3 years ago about another bug and nobody replied. So i guess this is a fastest solution. Maybe we should find another lib to replace this one.
https://github.com/andxu/yaml-parser

So as a temporary solution, i added another parsing using the yamljs lib. If the yaml is not formatted correctly it fails and skip the node-yaml-parser, otherwise it is called and it should not fail.

The fix can be validated by using the user example at https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1170