### PR TITLE
fix: debug attach not working with go app (#1184)

### DIFF
--- a/src/debug/goDebugProvider.ts
+++ b/src/debug/goDebugProvider.ts
@@ -32,22 +32,24 @@ export class GoDebugProvider implements IDebugProvider {
     }
 
     public async startDebugging(workspaceFolder: string, sessionName: string, port: number | undefined, _pod: string, _pidToDebug: number | undefined): Promise<boolean> {
+        const remotePath = await vscode.window.showInputBox({ 
+            prompt: "Which is the project root path of your remote app?", 
+            placeHolder: "/go/src/",
+            ignoreFocusOut: true,
+        });
+        if (remotePath === undefined) {
+            return false;
+        }
+        
         const debugConfiguration = {
             type: "go",
             request: "attach",
             mode: "remote",
             name: sessionName,
             hostName: "localhost",
-            remotePath: "${inputs.remotePath}",
+            remotePath,
             port,
-            inputs: [
-                {
-                    id: "remotePath",
-                    type: "promptString",
-                    description: "What is the remote dirpath for your app?",
-                    default: "/go/src/${workspaceFolderBasename}"
-                }
-            ]
+            cwd: workspaceFolder,
         };
         const currentFolder = (vscode.workspace.workspaceFolders || []).find((folder) => folder.name === path.basename(workspaceFolder));
         if (!currentFolder) {


### PR DESCRIPTION
It looks like the inputs field doesn't actually work. By looking at the examples on the vscode documentation I think it should be one level up the debug configuration but it's not possible if we create it by code.

Something like
```
{ 
 type: "go",
 request: "attach",
},
inputs: {
...
}
```

but we have 
```
{ 
 type: "go",
 request: "attach",
 inputs: {
    ...
  }
},
```

So this patch adds a new step to ask the user for the remote root path.

Another thing is that it was missing the current workspace variable.
it resolves #1184 and #1114 

To test it i used the `bacongobbler/helloworld-go` project. 
So cloned the repo, init/build the app. Created a Dockerfile having the dlv to debug it. Kubernetes run to push it on cluster, then attach debug.

```
# Create build stage based on buster image
FROM golang:1.20-buster AS builder
# Create working directory under /app
WORKDIR /app

RUN go install github.com/go-delve/delve/cmd/dlv@latest
# Copy over all go config (go.mod, go.sum etc.)
COPY go.* ./
# Install any required modules
RUN go mod download
# Copy over Go source code
COPY *.go ./
# Run the Go build and output binary under hello_go_http
RUN go build -o /hello_go_http
# Make sure to expose the port the HTTP server is using
EXPOSE 8080 40000
# Run the app binary when we run the container
CMD ["dlv", "--listen=:40000", "--headless=true", "--api-version=2", "--accept-multiclient", "exec", "/hello_go_http"]
```