### PR TITLE
fix: trim container name and filter empty ones (#1187)

### DIFF
--- a/src/components/logs/app/main.js
+++ b/src/components/logs/app/main.js
@@ -26,7 +26,7 @@ window.addEventListener('message', (event) => {
             const { containers, colors } = message;
             schemaColors = JSON.parse(colors);
             if (containers.length === 1) {
-                defaultContainer = containers[0];
+                defaultContainer = containers[0].name;
                 return;
             }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1392,9 +1392,10 @@ async function getContainerQuery(resource: ContainerContainer, containerType: st
     }
     const containersEx = c.result.map((s) => {
         const bits = s.split('\t');
-        return { name: bits[0], image: bits[1], initContainer: containerType === 'initContainers'};
+        return { name: bits[0] ? bits[0].trim() : '', image: bits[1] ? bits[1].trim() : '', initContainer: containerType === 'initContainers'};
     });
-    return containersEx;
+    
+    return containersEx.filter(c => c.name !== '');
 }
 
 export async function getContainersForResource(resource: ContainerContainer): Promise<Container[] | null> {


### PR DESCRIPTION
it resolves #1187 

There was also an issue in the log viewer. @Tatsinnit Please give a look at everything that comes to your mind that works with containers. https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/pull/1150 added some misbehavior apparently. Hopefully I tracked all issues. If you can do some other testing it would be better.

I guess we should make a new release when this is merged.