### PR TITLE
Fix tool path configuration handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Minikube tools to be installed and available on your PATH.
 
 ## Custom tool locations
 
-For `kubectl` and `helm`, the binaries do not need to be on the system PATH. You can configure the extension by specifying the locations using the appropriate `vs-kubernetes -> vs-kubernetes.${tool}-path` configuration setting.  See [Extension Settings](#extension-settings) below.
+For `kubectl` and `helm`, the binaries do not need to be on the system PATH. You can configure the extension by specifying the locations using the appropriate `vscode-kubernetes -> vscode-kubernetes.${tool}-path` configuration setting.  See [Extension Settings](#extension-settings) below.
 
 The extension can install `kubectl` and `helm` for you if they are missing - choose **Install dependencies** when you see an error notification for the missing tool.  This will set `kubectl-path` and `helm-path` entries in your configuration for the current OS (see "Portable extension configuration" below) - the programs will *not* be installed on the system PATH, but this will be sufficient for them to work with the extension.
 
@@ -240,10 +240,8 @@ For example, consider the following settings file:
 
 ```json
 {
-  "vscode-kubernetes": {
-    "vscode-kubernetes.kubectl-path": "/home/foo/kubernetes/bin/kubectl",
-    "vscode-kubernetes.kubectl-path-windows": "c:\\Users\\foo\\kubernetes\\bin\\kubectl.exe"
-  }
+  "vscode-kubernetes.kubectl-path": "/home/foo/kubernetes/bin/kubectl",
+  "vscode-kubernetes.kubectl-path-windows": "c:\\Users\\foo\\kubernetes\\bin\\kubectl.exe"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -232,17 +232,17 @@ If you are working with Azure Container Services or Azure Kubernetes Services, t
 
 If you move your configuration file between machines with different OSes (and therefore different paths to binaries) you can override the following settings on a per-OS basis by appending `.windows`, `.mac` or `.linux` to the setting name:
 
-  * `vs-kubernetes.kubectl-path`
-  * `vs-kubernetes.helm-path`
-  * `vs-kubernetes.minikube-path`
+  * `vscode-kubernetes.kubectl-path`
+  * `vscode-kubernetes.helm-path`
+  * `vscode-kubernetes.minikube-path`
 
 For example, consider the following settings file:
 
 ```json
 {
-  "vs-kubernetes": {
-    "vs-kubernetes.kubectl-path": "/home/foo/kubernetes/bin/kubectl",
-    "vs-kubernetes.kubectl-path.windows": "c:\\Users\\foo\\kubernetes\\bin\\kubectl.exe"
+  "vscode-kubernetes": {
+    "vscode-kubernetes.kubectl-path": "/home/foo/kubernetes/bin/kubectl",
+    "vscode-kubernetes.kubectl-path-windows": "c:\\Users\\foo\\kubernetes\\bin\\kubectl.exe"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Minikube tools to be installed and available on your PATH.
 
 ## Custom tool locations
 
-For `kubectl` and `helm`, the binaries do not need to be on the system PATH. You can configure the extension by specifying the locations using the appropriate `vscode-kubernetes -> vscode-kubernetes.${tool}-path` configuration setting.  See [Extension Settings](#extension-settings) below.
+For `kubectl` and `helm`, the binaries do not need to be on the system PATH. You can configure the extension by specifying the locations using the appropriate `vscode-kubernetes.${tool}-path` configuration setting.  See [Extension Settings](#extension-settings) below.
 
 The extension can install `kubectl` and `helm` for you if they are missing - choose **Install dependencies** when you see an error notification for the missing tool.  This will set `kubectl-path` and `helm-path` entries in your configuration for the current OS (see "Portable extension configuration" below) - the programs will *not* be installed on the system PATH, but this will be sufficient for them to work with the extension.
 

--- a/package.json
+++ b/package.json
@@ -342,55 +342,55 @@
                     "title": "Minikube path",
                     "description": "File path to a minikube binary. (You can override this on a per-OS basis if required)."
                 },
-                "vscode-kubernetes.kubectl-path.windows": {
+                "vscode-kubernetes.kubectl-path-windows": {
                     "type": "string",
                     "scope": "machine",
                     "title": "Path to kubectl (Windows)",
                     "description": "File path to a kubectl binary."
                 },
-                "vscode-kubernetes.helm-path.windows": {
+                "vscode-kubernetes.helm-path-windows": {
                     "type": "string",
                     "scope": "machine",
                     "title": "Helm path (Windows)",
                     "description": "File path to a helm binary."
                 },
-                "vscode-kubernetes.minikube-path.windows": {
+                "vscode-kubernetes.minikube-path-windows": {
                     "type": "string",
                     "scope": "machine",
                     "title": "Minikube path (Windows)",
                     "description": "File path to a minikube binary."
                 },
-                "vscode-kubernetes.kubectl-path.mac": {
+                "vscode-kubernetes.kubectl-path-mac": {
                     "type": "string",
                     "scope": "machine",
                     "title": "Path to kubectl (Mac)",
                     "description": "File path to a kubectl binary."
                 },
-                "vscode-kubernetes.helm-path.mac": {
+                "vscode-kubernetes.helm-path-mac": {
                     "type": "string",
                     "scope": "machine",
                     "title": "Helm path (Mac)",
                     "description": "File path to a helm binary."
                 },
-                "vscode-kubernetes.minikube-path.mac": {
+                "vscode-kubernetes.minikube-path-mac": {
                     "type": "string",
                     "scope": "machine",
                     "title": "Minikube path (Mac)",
                     "description": "File path to a minikube binary."
                 },
-                "vscode-kubernetes.kubectl-path.linux": {
+                "vscode-kubernetes.kubectl-path-linux": {
                     "type": "string",
                     "scope": "machine",
                     "title": "Path to kubectl (Linux)",
                     "description": "File path to a kubectl binary."
                 },
-                "vscode-kubernetes.helm-path.linux": {
+                "vscode-kubernetes.helm-path-linux": {
                     "type": "string",
                     "scope": "machine",
                     "title": "Helm path (Linux)",
                     "description": "File path to a helm binary."
                 },
-                "vscode-kubernetes.minikube-path.linux": {
+                "vscode-kubernetes.minikube-path-linux": {
                     "type": "string",
                     "scope": "machine",
                     "title": "Minikube path (Linux)",

--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -110,7 +110,7 @@ export function getToolPath(_host: Host, shell: Shell, tool: string): string | u
     const config = vscode.workspace.getConfiguration();
 
     const baseBackCompatKey = toolPathBackCompatBaseKey(tool);
-    const osBackCompatKey = osOverrideKey(os, baseBackCompatKey);
+    const osBackCompatKey = osBackCompatOverrideKey(os, baseBackCompatKey);
     const backCompatSettings = config.inspect<Dictionary<any>>(EXTENSION_CONFIG_KEY) || Dictionary.of<any>();
     const wsFolderValues = backCompatSettings.workspaceFolderValue || {};
     const wsValues = backCompatSettings.workspaceValue || {};
@@ -158,6 +158,11 @@ function toolPathBackCompatBaseKey(tool: string): string {
 
 function toolPathNewBaseKey(tool: string): string {
     return `vscode-kubernetes.${tool}-path`;
+}
+
+function osBackCompatOverrideKey(os: Platform, baseKey: string): string {
+    const osKey = osKeyString(os);
+    return osKey ? `${baseKey}.${osKey}` : baseKey;
 }
 
 function osOverrideKey(os: Platform, baseKey: string): string {

--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -140,7 +140,7 @@ export function getToolPath(_host: Host, shell: Shell, tool: string): string | u
         defaultValues[osKey] ||
         config.get(osKey) ||
         userValues[baseKey] ||
-        defaultValues[baseKey];
+        defaultValues[baseKey] ||
         config.get(baseKey);
 
     return interpolateVariables(topLevelToolPath || globalBackCompatSetting);
@@ -162,7 +162,7 @@ function toolPathNewBaseKey(tool: string): string {
 
 function osOverrideKey(os: Platform, baseKey: string): string {
     const osKey = osKeyString(os);
-    return osKey ? `${baseKey}.${osKey}` : baseKey;  // The 'else' clause should never happen so don't worry that this would result in double-checking a missing base key
+    return osKey ? `${baseKey}-${osKey}` : baseKey;  // The 'else' clause should never happen so don't worry that this would result in double-checking a missing base key
 }
 
 function osKeyString(os: Platform): string | null {


### PR DESCRIPTION
Configuring custom tool paths was not working correctly.

#1181 introduced a bug which causes the `baseKey` to not be handled at all.

Also, a configuration property in vscode cannot be a string and a object (with nested properties) at the same time.

eg. if you have both keys `vscode-kubernetes.kubectl-path` and `vscode-kubernetes.kubectl-path.linux` set, vscode will not return the nested `.linux` property at all. Therefore, it's better to use properties at the same level so that the overrides can work correctly (by changing `.` to `-`).

Also corrected the README.