### PR TITLE
disable kubectl command output in the debug console

### DIFF
--- a/src/shell.ts
+++ b/src/shell.ts
@@ -160,6 +160,7 @@ function execCore(cmd: string, opts: any, callback?: ((proc: ChildProcess) => vo
         if (getUseWsl()) {
             cmd = 'wsl ' + cmd;
         }
+        opts['silent'] = true;
         const proc = shelljs.exec(cmd, opts, (code, stdout, stderr) => resolve({code : code, stdout : stdout, stderr : stderr}));
         if (stdin) {
             proc.stdin.end(stdin);


### PR DESCRIPTION
Set kubectl commands to 'silent' because otherwise this extension makes the debug console in vscode unusable 