### PR TITLE
feat: add an option to disable Helm channel output

### DIFF
--- a/package.json
+++ b/package.json
@@ -294,6 +294,12 @@
                             ],
                             "description": "Set the smart code completion for CRDs. This would always prevent/allow the plugin to fetch all custom schemas from all CRDs on cluster, despite of their number."
                         },
+                        "vs-kubernetes.supress-output": {
+                            "type": "string",
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Set to true to silence Helm channel output"
+                        },
                         "vs-kubernetes.minikube-show-information-expiration": {
                             "type": "string",
                             "default": "Install",

--- a/package.json
+++ b/package.json
@@ -295,7 +295,6 @@
                             "description": "Set the smart code completion for CRDs. This would always prevent/allow the plugin to fetch all custom schemas from all CRDs on cluster, despite of their number."
                         },
                         "vs-kubernetes.supress-output": {
-                            "type": "string",
                             "type": "boolean",
                             "default": false,
                             "description": "Set to true to disable showing and stealing focus by Helm channel output window"

--- a/package.json
+++ b/package.json
@@ -298,7 +298,7 @@
                             "type": "string",
                             "type": "boolean",
                             "default": false,
-                            "description": "Set to true to silence Helm channel output"
+                            "description": "Set to true to disable showing and stealing focus by Helm channel output window"
                         },
                         "vs-kubernetes.minikube-show-information-expiration": {
                             "type": "string",

--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -208,7 +208,7 @@ export function getUseWsl(): boolean {
 }
 
 // minikube check upgrade
-const  MK_CHECK_UPGRADE_KEY = 'checkForMinikubeUpgrade';
+const MK_CHECK_UPGRADE_KEY = 'checkForMinikubeUpgrade';
 
 export function getCheckForMinikubeUpgrade(): boolean {
     return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)[MK_CHECK_UPGRADE_KEY];
@@ -343,6 +343,10 @@ export function getCRDCodeCompletionState(): string | undefined {
 export function setCRDCodeCompletion(enable: boolean): void {
     const value = (enable) ? 'enabled' : 'disabled';
     setConfigValue('vs-kubernetes.crd-code-completion', value);
+}
+
+export function supressOutput(): boolean {
+    return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.supress-output'];
 }
 
 export function getMinikubeShowInfoState(): string | undefined {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { supressOutput } from './components/config/config';
 
 const HELM_CHANNEL = "Helm";
 
@@ -17,7 +18,9 @@ class LoggingConsole implements Logger {
     log(msg: string) {
         this.channel.append(msg);
         this.channel.append("\n");
-        this.channel.show(true);
+        if (supressOutput()) {
+            this.channel.show(true);
+        }
     }
     dispose() {
         this.channel.dispose();


### PR DESCRIPTION
This channel may be annoying a bit, especially when your yaml in values is not valid. supress-output option makes a user able to turn showing output Helm channel off

fixes #1137 #1100 #929 #907 