### PR TITLE
Don't show convert on all files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [1.3.15]
+
+* Revert killTree changes. Detail discussion here https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1216
+
+Contributors: mikeseese, peterbom, michaellzc, mfilipe-te Thank you all!!
+
 ## [1.3.14]
 
 * Fix tool path configuration handling. (#1192)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-kubernetes-tools",
-    "version": "1.3.14",
+    "version": "1.3.15",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-kubernetes-tools",
-            "version": "1.3.14",
+            "version": "1.3.15",
             "license": "Apache-2.0",
             "dependencies": {
                 "@kubernetes/client-node": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-kubernetes-tools",
     "displayName": "Kubernetes",
     "description": "Develop, deploy and debug Kubernetes applications",
-    "version": "1.3.14",
+    "version": "1.3.15",
     "publisher": "ms-kubernetes-tools",
     "engines": {
         "vscode": "^1.52.0"

--- a/package.json
+++ b/package.json
@@ -497,7 +497,7 @@
                     "group": "2_k8s_3"
                 },
                 {
-                    "when": "",
+                    "when": "resourceLangId == yaml",
                     "command": "extension.helmConvertToTemplate",
                     "group": "2_helm@98"
                 }


### PR DESCRIPTION
Fixes #1231 by setting the conext menu in explorer to only YAML types.

Given this condition https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/blob/27835b6ced4607ac69bd66c73f344ee9c878abac/src/helm.authoring.ts#L39 this is an simple one to ensure it only shows on YAML files in the explorer and doesn't confuse users in other scenarios/contexts as 'Convert to Template' can be different things.

Signed-off-by: Tim Heuer <tim@timheuer.com>