### PR TITLE
Changes in correlation with new GH Action Permission Changes.

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -11,6 +11,11 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    permissions:
+        actions: read
+        contents: read
+        deployments: read
+        packages: none
     env:
       NODE_OPTIONS: --max_old_space_size=4096 --openssl-legacy-provider
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,11 @@ jobs:
   build:
     name: release
     runs-on: ubuntu-latest
-
+    permissions:
+        actions: read
+        contents: write
+        deployments: read
+        packages: none
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -17,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: npm install
     # Run tests
-    - name: Build 
+    - name: Build
       run: npm run compile
     - name: Get current package version
       id: package_version
@@ -31,7 +35,7 @@ jobs:
       id: create_release
       uses: actions/create-release@v1
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name : ${{ steps.package_version.outputs.current-version}}
         release_name: ${{ steps.package_version.outputs.current-version}}
@@ -51,5 +55,5 @@ jobs:
         asset_path: ${{ steps.create_vsix.outputs.vsixPath}}
         asset_name: ${{ steps.create_vsix.outputs.vsixPath}}
         asset_content_type: application/vsix
-    
+
 


### PR DESCRIPTION
These changes are made in correlation with the following changes coming soon in the GH actions permissions. Please take a kind look. ❤️🙏☕️

* https://docs.opensource.microsoft.com/github/apps/permission-changes/

To start with going with the most safest option with read only permission, for `publish` we need the `write for content`. Given this will spread pretty soon lets try this out and I will gradually open similarity changes in other repos I know.

<img width="676" alt="Screenshot 2024-01-22 at 11 41 38 AM" src="https://github.com/Azure/vscode-bridge-to-kubernetes/assets/6233295/5106db83-6dcd-41ac-942a-90a03cfaac96">

For Sample test if we do `content: read` for publish we will get some error like this which I tested in my fork for other project.

<img width="1714" alt="Screenshot 2024-01-22 at 11 27 19 AM" src="https://github.com/Azure/vscode-bridge-to-kubernetes/assets/6233295/b00462d5-d971-43d2-9c06-0d7c65f6b91c">

Thank you. ❤️🙏
