### PR TITLE
Fix per-OS configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ If you are working with Azure Container Services or Azure Kubernetes Services, t
 
 ### Portable extension configuration
 
-If you move your configuration file between machines with different OSes (and therefore different paths to binaries) you can override the following settings on a per-OS basis by appending `.windows`, `.mac` or `.linux` to the setting name:
+If you move your configuration file between machines with different OSes (and therefore different paths to binaries) you can override the following settings on a per-OS basis by appending `-windows`, `-mac` or `-linux` to the setting name:
 
   * `vscode-kubernetes.kubectl-path`
   * `vscode-kubernetes.helm-path`


### PR DESCRIPTION
Since #1192, `vscode-kubernetes`-prefixed settings use hyphen to separate the OS suffix from the configuration name. 0179492 updated the example but not the paragraph above, so update that now to avoid confusing someone else like it did me.