### PR TITLE
Added windows container shell support

### DIFF
--- a/src/utils/container-shell.ts
+++ b/src/utils/container-shell.ts
@@ -18,12 +18,20 @@ async function isPowerShellOnContainer(kubectl: Kubectl, podName: string, podNam
     return isFileOnContainer(kubectl, podName, podNamespace, containerName, checkCommand);
 }
 
+async function isCmdOnContainer(kubectl: Kubectl, podName: string, podNamespace: string | undefined, containerName: string | undefined): Promise<boolean> {
+    const checkCommand = 'cmd /C where cmd.exe';
+    return isFileOnContainer(kubectl, podName, podNamespace, containerName, checkCommand);
+}
+
 export async function suggestedShellForContainer(kubectl: Kubectl, podName: string, podNamespace: string | undefined, containerName: string | undefined): Promise<string> {
     if (await isBashOnContainer(kubectl, podName, podNamespace, containerName)) {
         return 'bash';
     }
     if (await isPowerShellOnContainer(kubectl, podName, podNamespace, containerName)) {
         return 'powershell.exe';
+    }
+    if (await isCmdOnContainer(kubectl, podName, podNamespace, containerName)) {
+        return 'cmd';
     }
     return 'sh';
 }

--- a/src/utils/container-shell.ts
+++ b/src/utils/container-shell.ts
@@ -1,16 +1,29 @@
 import { Kubectl } from "../kubectl";
 import { ExecResult } from "../binutilplusplus";
 
-async function isBashOnContainer(kubectl: Kubectl, podName: string, podNamespace: string | undefined, containerName: string | undefined): Promise<boolean> {
+async function isFileOnContainer(kubectl: Kubectl, podName: string, podNamespace: string | undefined, containerName: string | undefined, checkCommand: string): Promise<boolean> {
     const nsarg = podNamespace ? `--namespace ${podNamespace}` : '';
     const containerCommand = containerName ? `-c ${containerName}` : '';
-    const result = await kubectl.invokeCommand(`exec ${podName} ${nsarg} ${containerCommand} -- ls -la /bin/bash`);
+    const result = await kubectl.invokeCommand(`exec ${podName} ${nsarg} ${containerCommand} -- ${checkCommand}`);
     return ExecResult.succeeded(result);
+}
+
+async function isBashOnContainer(kubectl: Kubectl, podName: string, podNamespace: string | undefined, containerName: string | undefined): Promise<boolean> {
+    const checkCommand = 'ls -la /bin/bash';
+    return isFileOnContainer(kubectl, podName, podNamespace, containerName, checkCommand);
+}
+
+async function isPowerShellOnContainer(kubectl: Kubectl, podName: string, podNamespace: string | undefined, containerName: string | undefined): Promise<boolean> {
+    const checkCommand = 'cmd /C where powershell';
+    return isFileOnContainer(kubectl, podName, podNamespace, containerName, checkCommand);
 }
 
 export async function suggestedShellForContainer(kubectl: Kubectl, podName: string, podNamespace: string | undefined, containerName: string | undefined): Promise<string> {
     if (await isBashOnContainer(kubectl, podName, podNamespace, containerName)) {
         return 'bash';
+    }
+    if (await isPowerShellOnContainer(kubectl, podName, podNamespace, containerName)) {
+        return 'powershell.exe';
     }
     return 'sh';
 }

--- a/src/utils/container-shell.ts
+++ b/src/utils/container-shell.ts
@@ -14,12 +14,12 @@ async function isBashOnContainer(kubectl: Kubectl, podName: string, podNamespace
 }
 
 async function isPowerShellOnContainer(kubectl: Kubectl, podName: string, podNamespace: string | undefined, containerName: string | undefined): Promise<boolean> {
-    const checkCommand = 'cmd /C where powershell.exe';
+    const checkCommand = 'cmd.exe /C where powershell.exe';
     return isFileOnContainer(kubectl, podName, podNamespace, containerName, checkCommand);
 }
 
 async function isCmdOnContainer(kubectl: Kubectl, podName: string, podNamespace: string | undefined, containerName: string | undefined): Promise<boolean> {
-    const checkCommand = 'cmd /C where cmd.exe';
+    const checkCommand = 'cmd.exe /C where cmd.exe';
     return isFileOnContainer(kubectl, podName, podNamespace, containerName, checkCommand);
 }
 
@@ -31,7 +31,7 @@ export async function suggestedShellForContainer(kubectl: Kubectl, podName: stri
         return 'powershell.exe';
     }
     if (await isCmdOnContainer(kubectl, podName, podNamespace, containerName)) {
-        return 'cmd';
+        return 'cmd.exe';
     }
     return 'sh';
 }

--- a/src/utils/container-shell.ts
+++ b/src/utils/container-shell.ts
@@ -14,7 +14,7 @@ async function isBashOnContainer(kubectl: Kubectl, podName: string, podNamespace
 }
 
 async function isPowerShellOnContainer(kubectl: Kubectl, podName: string, podNamespace: string | undefined, containerName: string | undefined): Promise<boolean> {
-    const checkCommand = 'cmd /C where powershell';
+    const checkCommand = 'cmd /C where powershell.exe';
     return isFileOnContainer(kubectl, podName, podNamespace, containerName, checkCommand);
 }
 


### PR DESCRIPTION
Per issue https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/928 we don't handle a case for windows containers. Here is a quick fix to handle it.