### PR TITLE
Fix the package-ecosystem from empty to npm.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
+  - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This PR caters the `package-ecosystem` for the Dependabot for being `npm`.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem

Currently Dependabot is not happy because of the issue:

> The property '#/updates/0/package-ecosystem' value "" did not match one of the following values: npm, bundler, composer, devcontainers, maven, mix, cargo, gradle, nuget, gomod, docker, elm, gitsubmodule, github-actions, pip, terraform, pub, swift

For sample this should trigger updates like this: https://github.com/Tatsinnit/vscode-kubernetes-tools/pulls associate to #1276 

Thanks. ❤️🙏 fyi : @squillace , @hsubramanianaks , @qpetraroia fyi @gambtho