### PR TITLE
Fix typescript update for dependabot and relevant changes.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
                 "sinon": "^19.0.2",
                 "ts-loader": "^9.5.1",
                 "tslint": "^6.1.3",
-                "typescript": "^5.5.4",
+                "typescript": "^5.6.2",
                 "webpack": "^5.94.0",
                 "webpack-cli": "^5.1.4"
             },
@@ -9661,10 +9661,11 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.5.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-            "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+            "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1385,7 +1385,7 @@
         "sinon": "^19.0.2",
         "ts-loader": "^9.5.1",
         "tslint": "^6.1.3",
-        "typescript": "^5.5.4",
+        "typescript": "^5.6.2",
         "webpack": "^5.94.0",
         "webpack-cli": "^5.1.4"
     },

--- a/src/components/clusterexplorer/node.folder.resource.ts
+++ b/src/components/clusterexplorer/node.folder.resource.ts
@@ -57,13 +57,14 @@ export class ResourceFolderNode extends FolderNode implements ClusterExplorerRes
     private namespaceUriPart(ns: string, resources: string): string {
         let namespaceUri = `namespaces/${ns}/`;
         switch (resources) {
-            case "namespaces" || "nodes" || "persistentvolumes" || "storageclasses": {
+            case "namespaces":
+            case "nodes":
+            case "persistentvolumes":
+            case "storageclasses":
                 namespaceUri = '';
                 break;
-            }
-            default: {
+            default:
                 break;
-            }
         }
         return namespaceUri;
     }

--- a/src/components/clusterexplorer/node.resource.ts
+++ b/src/components/clusterexplorer/node.resource.ts
@@ -74,14 +74,15 @@ export class ResourceNode extends ClusterExplorerNodeImpl implements ClusterExpl
     private namespaceUriPart(ns: string, resources: string): string {
         let namespaceUri = '';
         switch (resources) {
-            case "namespaces" || "nodes" || "persistentvolumes" || "storageclasses": {
+            case "namespaces":
+            case "nodes":
+            case "persistentvolumes":
+            case "storageclasses":
                 namespaceUri = `${resources}/`;
                 break;
-            }
-            default: {
+            default:
                 namespaceUri = `namespaces/${ns}/${resources}/`;
                 break;
-            }
         }
         return namespaceUri;
     }


### PR DESCRIPTION
This PR is to fix #1344 key things is that:

The syntax case "A" || "B" is not valid in switch statements. We need to list each case individually, which is done here. Hence the other changes. One such example: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch#taking_advantage_of_fall-through 

Thank you folks., 