### PR TITLE
Publish release 1.13.17.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## [1.3.17]
+
+* feat: add an option to disable Helm channel output (#1208)
+* dependabpt PR's
+* Remove old site scaffolding project and Update/package dependencies (#1277)
+* Added snippet for ReplicaSet (#1268)
+* Prune and upgrade npm package dependencies (#1265)
+* Use vscode-single-select instead of vscode-select (#1294)
+* Fix the ubuntu failure. (#1279)
+
+Contributors: dbreyfogle, okgolove, peterbom, mikeseese, Thank you all!!
+
 ## [1.3.16]
 
 * Hide convert context menu (#1244)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [1.3.17]
 
 * feat: add an option to disable Helm channel output (#1208)
-* dependabpt PR's
+* dependabot PR's
 * Remove old site scaffolding project and Update/package dependencies (#1277)
 * Added snippet for ReplicaSet (#1268)
 * Prune and upgrade npm package dependencies (#1265)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-kubernetes-tools",
-    "version": "1.3.16",
+    "version": "1.3.17",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-kubernetes-tools",
-            "version": "1.3.16",
+            "version": "1.3.17",
             "license": "Apache-2.0",
             "dependencies": {
                 "@kubernetes/client-node": "^0.22.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-kubernetes-tools",
     "displayName": "Kubernetes",
     "description": "Develop, deploy and debug Kubernetes applications",
-    "version": "1.3.16",
+    "version": "1.3.17",
     "publisher": "ms-kubernetes-tools",
     "engines": {
         "vscode": "^1.93.0"


### PR DESCRIPTION
This PR is intended to open release for version `1.13.17` which carries following key things along with various dependant PR.

* feat: add an option to disable Helm channel output (#1208)
* dependabpt PR's
* Remove old site scaffolding project and Update/package dependencies (#1277)
* Added snippet for ReplicaSet (#1268)
* Prune and upgrade npm package dependencies (#1265)
* Use vscode-single-select instead of vscode-select (#1294)
* Fix the ubuntu failure. (#1279)

For testing reasons here is the VSIX please, thanks heaps. [vscode-kubernetes-tools-1.3.17-test.zip](https://github.com/user-attachments/files/17290561/vscode-kubernetes-tools-1.3.17-test.zip)

Thanks heaps, and :heart: gentle fyi to @qpetraroia , @hsubramanianaks , @ReinierCC & @tejhan cc: @squillace + @gambtho

