### PR TITLE
Publish release 1.3.18.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [1.3.18]
+
+* Fix clipboardy/webpack issue - breaking release 1.3.17 (#1355)
+
+Contributors: hsubramanianaks, anime-shed , kejatura-dev, ReinierCC, Also, an FYI, so suppress work will stay as it is.: qpetraroia, corneliusroemer, okgolove, tejhan, gambtho, squillace, metaphy6 , verhelstq  Thank you all!!
+
 ## [1.3.17]
 
 * feat: add an option to disable Helm channel output (#1208)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-kubernetes-tools",
-    "version": "1.3.17",
+    "version": "1.3.18",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-kubernetes-tools",
-            "version": "1.3.17",
+            "version": "1.3.18",
             "license": "Apache-2.0",
             "dependencies": {
                 "@kubernetes/client-node": "^0.22.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-kubernetes-tools",
     "displayName": "Kubernetes",
     "description": "Develop, deploy and debug Kubernetes applications",
-    "version": "1.3.17",
+    "version": "1.3.18",
     "publisher": "ms-kubernetes-tools",
     "engines": {
         "vscode": "^1.93.0"


### PR DESCRIPTION
This PR is intended to open release for version `1.13.18` which carries following key things along with various dependant PR. 

Most importantly this fixes a broken extension from previous release.

* Fix clipboardy/webpack issue - breaking release 1.3.17 #1355

Thanks heaps, and ❤️ gentle fyi to @qpetraroia , @hsubramanianaks , @ReinierCC & @tejhan cc: anime-shed , @kejatura-dev, @corneliusroemer, @okgolove, @metaphy6 , @verhelstq, @squillace + @gambtho ❤️ 