### PR TITLE
Fix update with engine udpate.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
                 "@types/tar": "^6.1.13",
                 "@types/tmp": "^0.2.6",
                 "@types/unzipper": "^0.10.9",
-                "@types/vscode": "^1.93.0",
+                "@types/vscode": "^1.94.0",
                 "@types/websocket": "^1.0.10",
                 "@types/yamljs": "^0.2.34",
                 "@typescript-eslint/eslint-plugin": "^8.8.1",
@@ -75,7 +75,7 @@
                 "webpack-cli": "^5.1.4"
             },
             "engines": {
-                "vscode": "^1.93.0"
+                "vscode": "^1.94.0"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -1057,9 +1057,9 @@
             }
         },
         "node_modules/@types/vscode": {
-            "version": "1.93.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.93.0.tgz",
-            "integrity": "sha512-kUK6jAHSR5zY8ps42xuW89NLcBpw1kOabah7yv38J8MyiYuOHxLQBi0e7zeXbQgVefDy/mZZetqEFC+Fl5eIEQ==",
+            "version": "1.94.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.94.0.tgz",
+            "integrity": "sha512-UyQOIUT0pb14XSqJskYnRwD2aG0QrPVefIfrW1djR+/J4KeFQ0i1+hjZoaAmeNf3Z2jleK+R2hv+EboG/m8ruw==",
             "dev": true,
             "license": "MIT"
         },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "version": "1.3.18",
     "publisher": "ms-kubernetes-tools",
     "engines": {
-        "vscode": "^1.93.0"
+        "vscode": "^1.94.0"
     },
     "license": "Apache-2.0",
     "categories": [
@@ -1372,7 +1372,7 @@
         "@types/tar": "^6.1.13",
         "@types/tmp": "^0.2.6",
         "@types/unzipper": "^0.10.9",
-        "@types/vscode": "^1.93.0",
+        "@types/vscode": "^1.94.0",
         "@types/websocket": "^1.0.10",
         "@types/yamljs": "^0.2.34",
         "@typescript-eslint/eslint-plugin": "^8.8.1",


### PR DESCRIPTION
This PR is raised ignorer to properly fix dependant update: https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/pull/1362 

with the vscode version update it is required to update the `engine` otherwise latter build will fail.

thank you so much.