### PR TITLE
Publish release 1.13.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## [1.3.19]
+
+* Simple clipboard implementation. (#1361)
+* Dependabot PR's
+* Fix update with engine udpate. (#1369)
+* Fix the vscode update. (#1384)
+* Changes in correlation with new GH Action Permission Changes. (#1247)
+* Fix the client-node update. (#1390)
+* Fix:Init container logs not working (#1391)
+* Fix build break. (#1419)
+* Update owner.md for Current Active Users and Project Collaboration (#1431)
+
+Contributors: bcmyguest, tejhan, ReinierCC, hsubramanianaks, qpetraroia Thank you all!!
+
+
 ## [1.3.18]
 
 * Fix clipboardy/webpack issue - breaking release 1.3.17 (#1355)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-kubernetes-tools",
-    "version": "1.3.18",
+    "version": "1.3.19",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-kubernetes-tools",
-            "version": "1.3.18",
+            "version": "1.3.19",
             "license": "Apache-2.0",
             "dependencies": {
                 "@kubernetes/client-node": "^0.22.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-kubernetes-tools",
     "displayName": "Kubernetes",
     "description": "Develop, deploy and debug Kubernetes applications",
-    "version": "1.3.18",
+    "version": "1.3.19",
     "publisher": "ms-kubernetes-tools",
     "engines": {
         "vscode": "^1.96.0"


### PR DESCRIPTION
This PR is intended to open release for version `1.13.19` which carries following key things along with various dependant PR.

* Simple clipboard implementation. (#1361)
* Dependabot PR's
* Fix update with engine udpate. (#1369)
* Fix the vscode update. (#1384)
* Changes in correlation with new GH Action Permission Changes. (#1247)
* Fix the client-node update. (#1390)
* Fix:Init container logs not working (#1391)
* Fix build break. (#1419)
* Update owner.md for Current Active Users and Project Collaboration (#1431)

Thanks heaps, and ❤️ gentle fyi to (Lets please get this quick spin around windows and other O/S please)  @hsubramanianaks , @ReinierCC, @tejhan &  @qpetraroia  ❤️ cc: @squillace 

**VSIX for quick test:** 

*  [vscode-kubernetes-tools-1.3.19-test.vsix.zip](https://github.com/user-attachments/files/18555647/vscode-kubernetes-tools-1.3.19-test.vsix.zip)
