### PR TITLE
Publish release 1.3.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [1.3.20]
 
-* Dependabot PR's
+* Dependabot PRs
 * Add the AKS logo to any AKS cluster. (#1440)
 
 Contributors: Reviews et al. tejhan, ReinierCC, hsubramanianaks, qpetraroia Thank you all!!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [1.3.20]
+
+* Dependabot PR's
+* Add the AKS logo to any AKS cluster. (#1440)
+
+Contributors: Reviews et. al. tejhan, ReinierCC, hsubramanianaks, qpetraroia Thank you all!!
+
 ## [1.3.19]
 
 * Simple clipboard implementation. (#1361)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 * Dependabot PR's
 * Add the AKS logo to any AKS cluster. (#1440)
 
-Contributors: Reviews et. al. tejhan, ReinierCC, hsubramanianaks, qpetraroia Thank you all!!
-
+Contributors: Reviews et al. tejhan, ReinierCC, hsubramanianaks, qpetraroia Thank you all!!
 ## [1.3.19]
 
 * Simple clipboard implementation. (#1361)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-kubernetes-tools",
-    "version": "1.3.19",
+    "version": "1.3.20",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-kubernetes-tools",
-            "version": "1.3.19",
+            "version": "1.3.20",
             "license": "Apache-2.0",
             "dependencies": {
                 "@kubernetes/client-node": "^0.22.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-kubernetes-tools",
     "displayName": "Kubernetes",
     "description": "Develop, deploy and debug Kubernetes applications",
-    "version": "1.3.19",
+    "version": "1.3.20",
     "publisher": "ms-kubernetes-tools",
     "engines": {
         "vscode": "^1.96.0"


### PR DESCRIPTION
This PR is intended to open release for version `1.13.20` which carries following key things along with various dependant PR.

* Dependabot PR's
* Add the AKS logo to any AKS cluster. (#1440)

Thanks heaps, and ❤️ gentle fyi to (Lets please get this quick spin around windows and other O/S please)  @hsubramanianaks , @ReinierCC, @tejhan &  @qpetraroia  ❤️ cc: @squillace 

**VSIX for quick test:** 

[vscode-kubernetes-tools-1.3.20-test.vsix.zip](https://github.com/user-attachments/files/18623971/vscode-kubernetes-tools-1.3.20-test.vsix.zip)
