### PR TITLE
remove acs and it's options

### DIFF
--- a/src/components/clusterprovider/azure/azure.ts
+++ b/src/components/clusterprovider/azure/azure.ts
@@ -1,13 +1,13 @@
 'use strict';
 
-import { compareVersions } from 'compare-versions';
-import { Errorable, failed } from '../../../errorable';
-import { FS } from '../../../fs';
 import { Shell } from '../../../shell';
+import { FS } from '../../../fs';
+import { ActionResult, fromShellJson, fromShellExitCodeAndStandardError, fromShellExitCodeOnly, Diagnostic } from '../../../wizard';
+import { Errorable, failed } from '../../../errorable';
+import { compareVersions } from 'compare-versions';
 import { sleep } from '../../../sleep';
-import { Dictionary } from '../../../utils/dictionary';
-import { ActionResult, Diagnostic, fromShellExitCodeAndStandardError, fromShellExitCodeOnly, fromShellJson } from '../../../wizard';
 import { getKubeconfigPath } from '../../kubectl/kubeconfig';
+import { Dictionary } from '../../../utils/dictionary';
 
 export interface Context {
     readonly fs: FS;

--- a/src/components/clusterprovider/azure/azure.ts
+++ b/src/components/clusterprovider/azure/azure.ts
@@ -105,6 +105,7 @@ export async function setSubscriptionAsync(context: Context, subscription: strin
     return fromShellExitCodeAndStandardError(sr, "Unable to set Azure CLI subscription");
 }
 
+// removed clusterType since it is NOT required after removing Azure Container Service option
 export async function getClusterList(context: Context, subscription: string): Promise<ActionResult<ClusterInfo[]>> {
     // log in
     const login = await setSubscriptionAsync(context, subscription);
@@ -264,6 +265,7 @@ export async function createCluster(context: Context, options: any): Promise<Act
     };
 }
 
+// removed clusterType since it is NOT required after removing Azure Container Service option
 export async function waitForCluster(context: Context, clusterName: string, clusterResourceGroup: string): Promise<Errorable<WaitResult>> {
     const clusterCmd = getClusterCommand();
     const waitCmd = `az ${clusterCmd} wait --created --interval 5 --timeout 10 -n ${clusterName} -g ${clusterResourceGroup} -o json`;

--- a/src/components/clusterprovider/azure/azure.ts
+++ b/src/components/clusterprovider/azure/azure.ts
@@ -1,13 +1,13 @@
 'use strict';
 
-import { Shell } from '../../../shell';
-import { FS } from '../../../fs';
-import { ActionResult, fromShellJson, fromShellExitCodeAndStandardError, fromShellExitCodeOnly, Diagnostic } from '../../../wizard';
-import { Errorable, failed } from '../../../errorable';
 import { compareVersions } from 'compare-versions';
+import { Errorable, failed } from '../../../errorable';
+import { FS } from '../../../fs';
+import { Shell } from '../../../shell';
 import { sleep } from '../../../sleep';
-import { getKubeconfigPath } from '../../kubectl/kubeconfig';
 import { Dictionary } from '../../../utils/dictionary';
+import { ActionResult, Diagnostic, fromShellExitCodeAndStandardError, fromShellExitCodeOnly, fromShellJson } from '../../../wizard';
+import { getKubeconfigPath } from '../../kubectl/kubeconfig';
 
 export interface Context {
     readonly fs: FS;
@@ -105,7 +105,7 @@ export async function setSubscriptionAsync(context: Context, subscription: strin
     return fromShellExitCodeAndStandardError(sr, "Unable to set Azure CLI subscription");
 }
 
-export async function getClusterList(context: Context, subscription: string, clusterType: string): Promise<ActionResult<ClusterInfo[]>> {
+export async function getClusterList(context: Context, subscription: string): Promise<ActionResult<ClusterInfo[]>> {
     // log in
     const login = await setSubscriptionAsync(context, subscription);
     if (failed(login)) {
@@ -116,34 +116,27 @@ export async function getClusterList(context: Context, subscription: string, clu
     }
 
     // list clusters
-    const clusters = await listClustersAsync(context, clusterType);
+    const clusters = await listClustersAsync(context);
     return {
         actionDescription: 'listing clusters',
         result: clusters
     };
 }
 
-async function listClustersAsync(context: Context, clusterType: string): Promise<Errorable<ClusterInfo[]>> {
-    const cmd = getListClustersCommand(context, clusterType);
+async function listClustersAsync(context: Context): Promise<Errorable<ClusterInfo[]>> {
+    const cmd = getListClustersCommand(context);
     const sr = await context.shell.exec(cmd);
 
     return fromShellJson<ClusterInfo[]>(sr, "Unable to list Kubernetes clusters");
 }
 
-function listClustersFilter(clusterType: string): string {
-    if (clusterType === 'acs') {
-        return '?orchestratorProfile.orchestratorType==`Kubernetes`';
-    }
-    return '';
-}
-
-function getListClustersCommand(context: Context, clusterType: string): string {
-    const filter = listClustersFilter(clusterType);
+function getListClustersCommand(context: Context): string {
+    const filter = '';
     let query = `[${filter}].{name:name,resourceGroup:resourceGroup}`;
     if (context.shell.isUnix()) {
         query = `'${query}'`;
     }
-    return `az ${getClusterCommand(clusterType)} list --query ${query} -ojson`;
+    return `az ${getClusterCommand()} list --query ${query} -ojson`;
 }
 
 async function listLocations(context: Context): Promise<Errorable<Locations>> {
@@ -161,19 +154,6 @@ async function listLocations(context: Context): Promise<Errorable<Locations>> {
         }
         return { locations: locations };
     });
-}
-
-export async function listAcsLocations(context: Context): Promise<Errorable<ServiceLocation[]>> {
-    const locationInfo = await listLocations(context);
-    if (failed(locationInfo)) {
-        return { succeeded: false, error: locationInfo.error };
-    }
-    const locations = locationInfo.result;
-
-    const sr = await context.shell.exec(`az acs list-locations -ojson`);
-
-    return fromShellJson<ServiceLocation[]>(sr, "Unable to list ACS locations", (response) =>
-        locationDisplayNamesEx(response.productionRegions, response.previewRegions, locations));
 }
 
 export async function listAksLocations(context: Context): Promise<Errorable<ServiceLocation[]>> {
@@ -214,7 +194,7 @@ function locationDisplayNames(names: string[], preview: boolean, locationInfo: L
 }
 
 function locationDisplayNamesEx(production: string[], preview: string[], locationInfo: Locations): ServiceLocation[] {
-    let result = locationDisplayNames(production, false, locationInfo) ;
+    let result = locationDisplayNames(production, false, locationInfo);
     result = result.concat(locationDisplayNames(preview, true, locationInfo));
     return result;
 }
@@ -225,7 +205,7 @@ export async function listVMSizes(context: Context, location: string): Promise<E
     return fromShellJson<string[]>(sr,
         "Unable to list Azure VM sizes",
         (response: any[]) => response.map((r) => r.name as string)
-                                      .filter((name) => !name.startsWith('Basic_'))
+            .filter((name) => !name.startsWith('Basic_'))
     );
 }
 
@@ -250,13 +230,9 @@ async function ensureResourceGroupAsync(context: Context, resourceGroupName: str
 }
 
 async function execCreateClusterCmd(context: Context, options: any): Promise<Errorable<Diagnostic>> {
-    const clusterCmd = getClusterCommand(options.clusterType);
+    const clusterCmd = getClusterCommand();
     let createCmd = `az ${clusterCmd} create -n "${options.metadata.clusterName}" -g "${options.metadata.resourceGroupName}" -l "${options.metadata.location}" --generate-ssh-keys --no-wait `;
-    if (clusterCmd === 'acs') {
-        createCmd = createCmd + `--agent-count ${options.agentSettings.count} --agent-vm-size "${options.agentSettings.vmSize}" -t Kubernetes`;
-    } else {
-        createCmd = createCmd + `--node-count ${options.agentSettings.count} --node-vm-size "${options.agentSettings.vmSize}"`;
-    }
+    createCmd = createCmd + `--node-count ${options.agentSettings.count} --node-vm-size "${options.agentSettings.vmSize}"`;
 
     const sr = await context.shell.exec(createCmd);
 
@@ -288,8 +264,8 @@ export async function createCluster(context: Context, options: any): Promise<Act
     };
 }
 
-export async function waitForCluster(context: Context, clusterType: string, clusterName: string, clusterResourceGroup: string): Promise<Errorable<WaitResult>> {
-    const clusterCmd = getClusterCommand(clusterType);
+export async function waitForCluster(context: Context, clusterName: string, clusterResourceGroup: string): Promise<Errorable<WaitResult>> {
+    const clusterCmd = getClusterCommand();
     const waitCmd = `az ${clusterCmd} wait --created --interval 5 --timeout 10 -n ${clusterName} -g ${clusterResourceGroup} -o json`;
     const sr = await context.shell.exec(waitCmd);
 
@@ -305,8 +281,8 @@ export async function waitForCluster(context: Context, clusterType: string, clus
 }
 
 export async function configureCluster(context: Context, clusterType: string, clusterName: string, clusterGroup: string): Promise<ActionResult<ConfigureResult>> {
-    const downloadKubectlCliPromise = downloadKubectlCli(context, clusterType);
-    const getCredentialsPromise = getCredentials(context, clusterType, clusterName, clusterGroup, 5);
+    const downloadKubectlCliPromise = downloadKubectlCli(context);
+    const getCredentialsPromise = getCredentials(context, clusterName, clusterGroup, 5);
 
     const [cliResult, credsResult] = await Promise.all([downloadKubectlCliPromise, getCredentialsPromise]);
 
@@ -326,8 +302,8 @@ export async function configureCluster(context: Context, clusterType: string, cl
     };
 }
 
-async function downloadKubectlCli(context: Context, clusterType: string): Promise<any> {
-    const cliInfo = installKubectlCliInfo(context, clusterType);
+async function downloadKubectlCli(context: Context): Promise<any> {
+    const cliInfo = installKubectlCliInfo(context);
 
     const sr = await context.shell.exec(cliInfo.commandLine);
 
@@ -349,14 +325,14 @@ async function downloadKubectlCli(context: Context, clusterType: string): Promis
     }
 }
 
-async function getCredentials(context: Context, clusterType: string, clusterName: string, clusterGroup: string, maxAttempts: number): Promise<any> {
+async function getCredentials(context: Context, clusterName: string, clusterGroup: string, maxAttempts: number): Promise<any> {
     const kubeconfigPath = getKubeconfigPath();
     const kubeconfigFilePath = kubeconfigPath.pathType === "host" ? kubeconfigPath.hostPath : kubeconfigPath.wslPath;
     const kubeconfigFileOption = kubeconfigFilePath ? `-f "${kubeconfigFilePath}"` : '';
     let attempts = 0;
     while (true) {
         attempts++;
-        const cmd = `az ${getClusterCommandAndSubcommand(clusterType)} get-credentials -n ${clusterName} -g ${clusterGroup} ${kubeconfigFileOption}`;
+        const cmd = `az ${getClusterCommandAndSubcommand()} get-credentials -n ${clusterName} -g ${clusterGroup} ${kubeconfigFileOption}`;
         const sr = await context.shell.exec(cmd);
 
         if (sr && sr.code === 0 && !sr.stderr) {
@@ -374,8 +350,8 @@ async function getCredentials(context: Context, clusterType: string, clusterName
     }
 }
 
-function installKubectlCliInfo(context: Context, clusterType: string) {
-    const cmdCore = `az ${getClusterCommandAndSubcommand(clusterType)} install-cli`;
+function installKubectlCliInfo(context: Context) {
+    const cmdCore = `az ${getClusterCommandAndSubcommand()} install-cli`;
     const isWindows = context.shell.isWindows();
     if (isWindows) {
         // The default Windows install location requires admin permissions; install
@@ -398,16 +374,10 @@ function installKubectlCliInfo(context: Context, clusterType: string) {
     }
 }
 
-function getClusterCommand(clusterType: string): string {
-    if (clusterType === 'Azure Container Service' || clusterType === 'acs') {
-        return 'acs';
-    }
+function getClusterCommand(): string {
     return 'aks';
 }
 
-function getClusterCommandAndSubcommand(clusterType: string): string {
-    if (clusterType === 'Azure Container Service' || clusterType === 'acs') {
-        return 'acs kubernetes';
-    }
+function getClusterCommandAndSubcommand(): string {
     return 'aks';
 }

--- a/src/components/clusterprovider/azure/azureclusterprovider.ts
+++ b/src/components/clusterprovider/azure/azureclusterprovider.ts
@@ -1,21 +1,20 @@
-import * as clusterproviderregistry from '../clusterproviderregistry';
-import * as azure from './azure';
-import { styles, formStyles, waitScript, ActionResult, Diagnostic } from '../../../wizard';
-import { Errorable, succeeded, failed, Failed, Succeeded } from '../../../errorable';
-import { formPage, propagationFields } from '../common/form';
-import { refreshExplorer } from '../common/explorer';
-import { Wizard, NEXT_FN } from '../../wizard/wizard';
-import { Sequence, Observable } from '../../../utils/observable';
-import { trackReadiness } from '../readinesstracker';
+import { Errorable, failed, Failed, succeeded, Succeeded } from '../../../errorable';
 import { reporter } from '../../../telemetry';
+import { Observable, Sequence } from '../../../utils/observable';
+import { ActionResult, Diagnostic, formStyles, styles, waitScript } from '../../../wizard';
+import { NEXT_FN, Wizard } from '../../wizard/wizard';
+import * as clusterproviderregistry from '../clusterproviderregistry';
+import { refreshExplorer } from '../common/explorer';
+import { formPage, propagationFields } from '../common/form';
+import { trackReadiness } from '../readinesstracker';
+import * as azure from './azure';
 
 // TODO: de-globalise
 let registered = false;
 
 export async function init(registry: clusterproviderregistry.ClusterProviderRegistry, context: azure.Context): Promise<void> {
     if (!registered) {
-        registry.register({id: 'aks', displayName: "Azure Kubernetes Service", supportedActions: ['create', 'configure'], next: (w, a, m) => next(context, w, a, m)});
-        registry.register({id: 'acs', displayName: "Azure Container Service", supportedActions: ['create', 'configure'], next: (w, a, m) => next(context, w, a, m)});
+        registry.register({ id: 'aks', displayName: "Azure Kubernetes Service", supportedActions: ['create', 'configure'], next: (w, a, m) => next(context, w, a, m) });
         registered = true;
     }
 }
@@ -97,7 +96,7 @@ async function promptForSubscription(previousData: any, context: azure.Context, 
 }
 
 async function promptForCluster(previousData: any, context: azure.Context): Promise<string> {
-    const clusterList = await azure.getClusterList(context, previousData.subscription, previousData.clusterType);
+    const clusterList = await azure.getClusterList(context, previousData.subscription);
 
     if (!clusterList.result.succeeded) {
         return renderCliError('PromptForCluster', clusterList);
@@ -136,9 +135,7 @@ async function configureKubernetes(previousData: any, context: azure.Context): P
 }
 
 async function promptForMetadata(previousData: any, context: azure.Context): Promise<string> {
-    const serviceLocations = previousData.clusterType === 'acs' ?
-        await azure.listAcsLocations(context) :
-        await azure.listAksLocations(context);
+    const serviceLocations = await azure.listAksLocations(context);
 
     if (!serviceLocations.succeeded) {
         return renderCliError('PromptForMetadata', {
@@ -214,7 +211,8 @@ async function createCluster(previousData: any, context: azure.Context): Promise
             count: previousData.agentcount,
             vmSize: previousData.agentvmsize
 
-        } };
+        }
+    };
     const createResult = await azure.createCluster(context, options);
 
     if (reporter) {
@@ -256,7 +254,7 @@ function refreshCountIndicator(refreshCount: number): string {
 function waitForClusterAndReportConfigResult(previousData: any, context: azure.Context): Observable<string> {
 
     async function waitOnce(refreshCount: number): Promise<[string, boolean]> {
-        const waitResult = await azure.waitForCluster(context, previousData.clusterType, previousData.clustername, previousData.resourcegroupname);
+        const waitResult = await azure.waitForCluster(context, previousData.clustername, previousData.resourcegroupname);
         if (failed(waitResult)) {
             return [`<h1>Error creating cluster</h1><p>Error details: ${waitResult.error[0]}</p>`, false];
         }
@@ -343,7 +341,7 @@ function renderCliError<T>(stageId: string, last: ActionResult<T>): string {
         <ul>
         <li>Log into the Azure CLI (run az login in the terminal)</li>
         <li>Install the Azure CLI <a href='https://docs.microsoft.com/cli/azure/install-azure-cli'>(see the instructions for your operating system)</a></li>
-        <li>Configure Kubernetes from the command line using the az acs or az aks command</li>
+        <li>Configure Kubernetes from the command line using the az aks command</li>
         </ul>
         <p><b>Details</b></p>
         <p>${errorInfo.error}</p>`;

--- a/src/components/clusterprovider/azure/azureclusterprovider.ts
+++ b/src/components/clusterprovider/azure/azureclusterprovider.ts
@@ -1,13 +1,13 @@
-import { Errorable, failed, Failed, succeeded, Succeeded } from '../../../errorable';
-import { reporter } from '../../../telemetry';
-import { Observable, Sequence } from '../../../utils/observable';
-import { ActionResult, Diagnostic, formStyles, styles, waitScript } from '../../../wizard';
-import { NEXT_FN, Wizard } from '../../wizard/wizard';
 import * as clusterproviderregistry from '../clusterproviderregistry';
-import { refreshExplorer } from '../common/explorer';
-import { formPage, propagationFields } from '../common/form';
-import { trackReadiness } from '../readinesstracker';
 import * as azure from './azure';
+import { styles, formStyles, waitScript, ActionResult, Diagnostic } from '../../../wizard';
+import { Errorable, succeeded, failed, Failed, Succeeded } from '../../../errorable';
+import { formPage, propagationFields } from '../common/form';
+import { refreshExplorer } from '../common/explorer';
+import { Wizard, NEXT_FN } from '../../wizard/wizard';
+import { Sequence, Observable } from '../../../utils/observable';
+import { trackReadiness } from '../readinesstracker';
+import { reporter } from '../../../telemetry';
 
 // TODO: de-globalise
 let registered = false;


### PR DESCRIPTION
This PR removes the Azure Container Services options which no longer exists and replaced with Azure Kubernetes Services. 

Only AKS and minikube options are provided now. Please reach out if you have any questions. Thank you all. 

Tested in Ubuntu, works well cc: @qpetraroia @Tatsinnit 

![image](https://github.com/user-attachments/assets/a1e8a0ae-04e7-4956-b98a-79715439e85f)
