### PR TITLE
Potential fix for code scanning alert no. 5: Client-side cross-site scripting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1356,7 +1356,8 @@
         "vscode-extension-telemetry": "^0.4.5",
         "vscode-uri": "^3.1.0",
         "yaml-ast-parser": "^0.0.43",
-        "yamljs": "^0.3.0"
+        "yamljs": "^0.3.0",
+        "dompurify": "^3.2.4"
     },
     "devDependencies": {
         "@bendera/vscode-webview-elements": "^0.17.2",

--- a/src/components/logs/app/main.js
+++ b/src/components/logs/app/main.js
@@ -1,4 +1,5 @@
 const vscode = acquireVsCodeApi();
+const DOMPurify = require('dompurify');
 const Convert = require('ansi-to-html');
 const convert = new Convert();
 
@@ -599,7 +600,7 @@ function render(content, from, prepend) {
         const fragment = document.createRange().createContextualFragment('No logs ...');
         contentElement.appendChild(fragment);
     } else {
-        const contentToDisplay = concatenateObjectValuesAsString(content, from);
+        const contentToDisplay = DOMPurify.sanitize(concatenateObjectValuesAsString(content, from));
         const fragment = document.createRange().createContextualFragment(contentToDisplay);
         if (prepend) {
             contentElement.prepend(fragment);


### PR DESCRIPTION
Potential fix for [https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/security/code-scanning/5](https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/security/code-scanning/5)

To fix the problem, we need to ensure that any user-provided data is properly sanitized or escaped before being rendered into the DOM. The best way to fix this issue without changing existing functionality is to use a library that provides contextual output encoding/escaping. One such library is `DOMPurify`, which can sanitize HTML and prevent XSS attacks.

We will sanitize the `contentToDisplay` variable before creating a contextual fragment and appending it to the DOM. This change will be made in the `render` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
