### PR TITLE
Fix some scanning alerts.

### DIFF
--- a/src/kubectlUtils.ts
+++ b/src/kubectlUtils.ts
@@ -116,7 +116,9 @@ export async function getContexts(kubectl: Kubectl, options: ConfigReadOptions):
     const cluster = clusters.find((cl) => cl.name === c.context.cluster);
 
     // Extract provider type from the cluster's server property if it includes "azk8ms"
-    const provider = cluster?.cluster?.server?.includes('azmk8s.io') ? 'AKS' : '';
+    const azurePattern = /(^|\.)azmk8s\.io(?=$|\/|\?)/i;
+    const provider = azurePattern.test(cluster?.cluster?.server || '') ? 'AKS' : '';
+
     return {
             clusterName: c.context.cluster,
             contextName: c.name,

--- a/src/telemetry-helper.ts
+++ b/src/telemetry-helper.ts
@@ -154,7 +154,10 @@ async function inferCurrentClusterType(kubectl: Kubectl): Promise<[ClusterType, 
     }
 
     const masterInfo = masterInfos[0];
-    if (masterInfo.indexOf('azmk8s.io') >= 0 || masterInfo.indexOf('azure.com') >= 0) {
+    const azurePattern = /(^|\.)azmk8s\.io(?=$|\/|\?)/i;
+    const azureComPattern = /(^|\.)azure\.com(?=$|\/|\?)/i;
+
+    if (azurePattern.test(masterInfo) || azureComPattern.test(masterInfo)) {
         return [ClusterType.Azure, NonDeterminationReason.None];
     }
 


### PR DESCRIPTION
This PR is to fix few scanning alerts agains this repo, so mainly the changes are to :

1. Ensures correct domain structure: 
   - Matches `"azmk8s.io"` or `"azure.com"` **only when it appears as a full domain or subdomain** (e.g., `sub.azmk8s.io`, `xyz.azure.com`).  
   - Prevents arbitrary words like `"maliciousazmk8s.io.evil.com"` from passing.  

2. Avoids partial matches inside strings:
   - `"exampleazmk8s.io"` (will fail)
   - `"abc.azmk8s.io"` (will succeed)

Thanks heaps, fyi @ReinierCC , @tejhan, @bosesuneha, @qpetraroia , @squillace, @davidgamero