### PR TITLE
Publish release 1.3.22.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [1.3.22]
+
+* Dependabot PRs
+* feat: warn about lack of CPU and memory requests (#1493)
+* Fix: broken telemetry due to old logic in place. #1500
+
+Contributors: Contributions and Reviews to davidxia, tejhan, bosesuneha, davidgamero, ReinierCC, qpetraroia Thank you all!!
+
 ## [1.3.21]
 
 * Dependabot PRs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-kubernetes-tools",
-    "version": "1.3.21",
+    "version": "1.3.22",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-kubernetes-tools",
-            "version": "1.3.21",
+            "version": "1.3.22",
             "license": "Apache-2.0",
             "dependencies": {
                 "@kubernetes/client-node": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-kubernetes-tools",
     "displayName": "Kubernetes",
     "description": "Develop, deploy and debug Kubernetes applications",
-    "version": "1.3.21",
+    "version": "1.3.22",
     "publisher": "ms-kubernetes-tools",
     "engines": {
         "vscode": "^1.98.0"


### PR DESCRIPTION
This PR is intended to open release for version `1.13.22` which carries following key things along with various dependant PR.

* Dependabot PRs
* feat: warn about lack of CPU and memory requests (#1493)
* Fix: broken telemetry due to old logic in place. #1500

Thanks heaps, and ❤️ gentle fyi to (Lets please get this quick spin around windows and other O/S please)  @ReinierCC, @tejhan, @bosesuneha , @davidgamero &  @qpetraroia  ❤️ cc: @squillace , @gambtho

**VSIX for quick test:** 

[vscode-kubernetes-tools-1.3.22-test.vsix.zip](https://github.com/user-attachments/files/19766483/vscode-kubernetes-tools-1.3.22-test.vsix.zip)

