### PR TITLE
Add existing cluster [Fix]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "1.3.22",
             "license": "Apache-2.0",
             "dependencies": {
+                "@azure/arm-containerservice": "^21.5.0",
                 "@kubernetes/client-node": "^1.1.0",
                 "@microsoft/vscode-azext-azureauth": "^4.1.1",
                 "@vscode/test-electron": "^2.5.2",
@@ -101,6 +102,36 @@
                 "node": ">=12.0.0"
             }
         },
+        "node_modules/@azure/arm-containerservice": {
+            "version": "21.5.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-containerservice/-/arm-containerservice-21.5.0.tgz",
+            "integrity": "sha512-EVyqS17GydR3QlvDQrgD/PsUmwqofUw3Hje4uPW0lNG8RModAUo+DP/+6WqMwId1Etdd6C+v/yIkOxyxVL6IWw==",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/abort-controller": "^2.1.2",
+                "@azure/core-auth": "^1.9.0",
+                "@azure/core-client": "^1.9.2",
+                "@azure/core-lro": "^2.5.4",
+                "@azure/core-paging": "^1.6.2",
+                "@azure/core-rest-pipeline": "^1.19.0",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@azure/arm-containerservice/node_modules/@azure/abort-controller": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+            "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/@azure/arm-resources-subscriptions": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/@azure/arm-resources-subscriptions/-/arm-resources-subscriptions-2.1.0.tgz",
@@ -117,12 +148,13 @@
             }
         },
         "node_modules/@azure/core-auth": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.7.2.tgz",
-            "integrity": "sha512-Igm/S3fDYmnMq1uKS38Ae1/m37B3zigdlZw+kocwEhh5GjyKjPrXKO2J6rzpC1wAxrNil/jX9BJRqBshyjnF3g==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.9.0.tgz",
+            "integrity": "sha512-FPwHpZywuyasDSLMqJ6fhbOK3TqUdviZNF8OqRGA4W5Ewib2lEEZ+pBsYcBa88B2NGO/SEnYPGhyBqNlE8ilSw==",
+            "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^2.0.0",
-                "@azure/core-util": "^1.1.0",
+                "@azure/core-util": "^1.11.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -168,6 +200,33 @@
                 "node": ">=18.0.0"
             }
         },
+        "node_modules/@azure/core-lro": {
+            "version": "2.7.2",
+            "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
+            "integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/abort-controller": "^2.0.0",
+                "@azure/core-util": "^1.2.0",
+                "@azure/logger": "^1.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@azure/core-lro/node_modules/@azure/abort-controller": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+            "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/@azure/core-paging": {
             "version": "1.6.2",
             "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
@@ -180,14 +239,15 @@
             }
         },
         "node_modules/@azure/core-rest-pipeline": {
-            "version": "1.16.3",
-            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.16.3.tgz",
-            "integrity": "sha512-VxLk4AHLyqcHsfKe4MZ6IQ+D+ShuByy+RfStKfSjxJoL3WBWq17VNmrz8aT8etKzqc2nAeIyLxScjpzsS4fz8w==",
+            "version": "1.19.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.19.1.tgz",
+            "integrity": "sha512-zHeoI3NCs53lLBbWNzQycjnYKsA1CVKlnzSNuSFcUDwBp8HHVObePxrM7HaX+Ha5Ks639H7chNC9HOaIhNS03w==",
+            "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^2.0.0",
-                "@azure/core-auth": "^1.4.0",
+                "@azure/core-auth": "^1.8.0",
                 "@azure/core-tracing": "^1.0.1",
-                "@azure/core-util": "^1.9.0",
+                "@azure/core-util": "^1.11.0",
                 "@azure/logger": "^1.0.0",
                 "http-proxy-agent": "^7.0.0",
                 "https-proxy-agent": "^7.0.0",
@@ -220,9 +280,10 @@
             }
         },
         "node_modules/@azure/core-util": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.9.2.tgz",
-            "integrity": "sha512-l1Qrqhi4x1aekkV+OlcqsJa4AnAkj5p0JV8omgwjaV9OAbP41lvrMvs+CptfetKkeEaGRGSzby7sjPZEX7+kkQ==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.11.0.tgz",
+            "integrity": "sha512-DxOSLua+NdpWoSqULhjDyAZTXFdP/LKkqtYuxxz1SCN289zk3OG8UOpnCQAz/tygyACBtWp/BoO72ptK7msY8g==",
+            "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^2.0.0",
                 "tslib": "^2.6.2"
@@ -9665,9 +9726,10 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
         },
         "node_modules/tslint": {
             "version": "6.1.3",

--- a/package.json
+++ b/package.json
@@ -1261,6 +1261,7 @@
         "redhat.vscode-yaml"
     ],
     "dependencies": {
+        "@azure/arm-containerservice": "^21.5.0",
         "@kubernetes/client-node": "^1.1.0",
         "@microsoft/vscode-azext-azureauth": "^4.1.1",
         "@vscode/test-electron": "^2.5.2",

--- a/src/components/cloudprovider/aksprovider.ts
+++ b/src/components/cloudprovider/aksprovider.ts
@@ -34,7 +34,7 @@ export class AKSProvider implements CloudProvider {
         );
 
         if (!selectedSubscription) {
-            vscode.window.showErrorMessage(`Failed to get subscriptions for ${this.getName()}`);
+            vscode.window.showErrorMessage(`Failed to get subscription for ${this.getName()}`);
             return;
         }
         return subscriptions.find((sub) => sub.name === selectedSubscription)?.subscriptionId;
@@ -128,6 +128,32 @@ export class AKSProvider implements CloudProvider {
         }));
     }
 
+    // prompts the user to select a cluster & returns the selected cluster
+    async selectCluster(subscriptionId: string){
+        const clusters = await this.listClusters(subscriptionId);
+        if (clusters && clusters.length > 0) {
+            // prompt for selecting cluster
+            const selectedCluster = await vscode.window.showQuickPick(
+                        clusters.map((cluster:any) => cluster.name),
+                        { placeHolder: "Select the cluster" }
+            );
+            if (!selectedCluster) {
+                vscode.window.showErrorMessage(`Failed to get cluster`);
+                return undefined;
+            } else {
+                let cluster = clusters.find((cluster:any) => cluster.name === selectedCluster);
+                if (!cluster) {
+                    vscode.window.showErrorMessage(`Failed to get cluster`);
+                    return undefined;
+                } else {
+                    return cluster;
+                }
+            }
+        } else {
+            vscode.window.showErrorMessage("No clusters found.");
+            return undefined;
+        }
+    }
     // retrieves the credentials for the given cluster
     async getCredentials(){
         const session = await vscode.authentication.getSession(

--- a/src/components/cloudprovider/aksprovider.ts
+++ b/src/components/cloudprovider/aksprovider.ts
@@ -1,6 +1,8 @@
 import { VSCodeAzureSubscriptionProvider } from "@microsoft/vscode-azext-azureauth";
 import * as vscode from "vscode";
 import { longRunning } from "../../utils/notification";
+import { TokenCredential } from "@azure/core-auth";
+import { ContainerServiceClient } from "@azure/arm-containerservice";
 
 export class AKSProvider implements CloudProvider {
     private provider = new VSCodeAzureSubscriptionProvider();
@@ -63,6 +65,116 @@ export class AKSProvider implements CloudProvider {
             await vscode.commands.executeCommand("aks.createCluster", inputs);
         }
     }
+
+    // retrieves the list of AKS clusters in the given subscription
+    async listClusters(subscriptionId: string): Promise<{ name: string; resourceGroup: string; }[] | undefined> {
+        // getting active session
+        const session = await vscode.authentication.getSession(
+            "microsoft",
+            ["https://management.azure.com/.default"],
+            { createIfNone: true }
+        );
+        if (!session) {
+            vscode.window.showErrorMessage("You must be signed into Azure to list clusters.");
+            return;
+        }
+
+        const token = session.accessToken;
+
+        // The logic below does the same thing as the ResourceGraphClient, but we are using 
+        // the REST API directly to avoid bundling issues we currently have.
+        // After we undergo major updates 
+        // to address our outdated/broken dependencies, we can revisit this.
+
+        const url = "https://management.azure.com/providers/Microsoft.ResourceGraph/resources?api-version=2021-03-01";
+        const body = {
+            subscriptions: [subscriptionId],
+            query: "Resources | where type =~ 'Microsoft.ContainerService/managedClusters' | project name, resourceGroup"
+        };
+
+        let resp;
+        try {
+            // using fetch to call the Resource Graph API
+            resp = await fetch(url, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify(body)
+            });
+        } catch (e: any) {
+            vscode.window.showErrorMessage(`Network error querying Resource Graph: ${e.message}`);
+            return;
+        }
+    
+        if (!resp.ok) {
+            vscode.window.showErrorMessage(`Resource Graph failed: ${resp.status} ${resp.statusText}`);
+            return;
+        }
+
+        // parsing the response
+        let json: any;
+        try {
+            json = await resp.json();
+        } catch (e: any) {
+            vscode.window.showErrorMessage(`Invalid JSON from Resource Graph: ${e.message}`);
+            return;
+        }
+    
+        return (json.data as any[]).map((c) => ({
+            name: c.name,
+            resourceGroup: c.resourceGroup
+        }));
+    }
+
+    // retrieves the credentials for the given cluster
+    async getCredentials(){
+        const session = await vscode.authentication.getSession(
+            "microsoft",
+            ["https://management.azure.com/.default"],
+            { createIfNone: true }
+        );
+        if (!session) {
+            vscode.window.showErrorMessage("You must be signed into Azure to list clusters.");
+            return;
+        }
+        return {
+            getToken: async () => ({
+                token: session.accessToken,
+                expiresOnTimestamp: 0,
+            }),
+        } as TokenCredential;
+    }
+    // gets kubeconfig yaml for the given cluster
+    async getKubeconfigYaml(
+        subscriptionId: string,
+        resourceGroup: string,
+        clusterName: string
+    ): Promise<string | undefined> {
+        const credential = await this.getCredentials();
+        if (!credential) {
+            vscode.window.showErrorMessage("Failed to get credentials for AKS.");
+            return;
+        }
+        const client = new ContainerServiceClient(credential, subscriptionId);
+        try {
+            // Using the ContainerServiceClient to get the kubeconfig
+            const result = await client.managedClusters.listClusterUserCredentials(resourceGroup, clusterName);
+            const kubeconfigBase64 = result.kubeconfigs?.[0]?.value;
+        if (!kubeconfigBase64) {
+            vscode.window.showErrorMessage("Failed to retrieve kubeconfig from AKS.");
+            return;
+        }
+        // Convert the base64 string to a usable UTF-8 string
+        const kubeconfigYaml = Buffer.from(kubeconfigBase64).toString("utf8");
+        return kubeconfigYaml;
+        } catch (err) {
+            vscode.window.showErrorMessage(`Error fetching kubeconfig: ${(err as any).message || String(err)}`);
+            return;
+        }
+    }
+
 }
 
 async function waitForExtension(extensionId: string): Promise<boolean> {


### PR DESCRIPTION
This PR serves to fix the implementation for adding an existing cluster, now allowing users to properly add AKS clusters to their kubeconfig & interactable cluster tree in the extension.

The functionality for adding an existing cluster was not working as expected, likely due to older code / deprecated packages. Included below is documentation of observed broken behavior & new implementation for easy reference.

**Observed Behavior**

https://github.com/user-attachments/assets/cb984cf4-2e2d-477d-a91c-cb5253f4e18a

**New Behavior** 

https://github.com/user-attachments/assets/e4b97f72-3a6a-4c4f-9df3-a715630b2e92

**.vsix for testing:** [vscode-kubernetes-tools-1.3.22-addexistingcluster.vsix.zip](https://github.com/user-attachments/files/19817289/vscode-kubernetes-tools-1.3.22-addexistingcluster.vsix.zip)

**Testing instructions:** Click the 3 dots in the "Clusters" Sidebar, then select "Add Existing Cluster" -> select the cluster type (Currently AKS), then select the cluster subscription. If no clusters are found, user should be notified. If some are found, select one from the provided list & then observe if kubeconfig is properly populated with new cluster.


(Note: When developing this fix, several issues arose due to outdated / deprecated packages in the extension, so we should start phasing out all deprecated packages & update (where necessary) ones we are actively utilizing.


