### PR TITLE
[Fix] Broken behavior when viewing large pod logs in webview

### DIFF
--- a/src/components/logs/app/main.js
+++ b/src/components/logs/app/main.js
@@ -237,8 +237,20 @@ function resetFilter() {
 function runFilter() {
     emptyContent();
     saveFilteredContent();
+    setHeightContentPanel();
     renderByPagination();
 }
+
+function setHeightContentPanel(remove = false) {
+    const panel = document.getElementById('innerLogPanel');
+    if (remove) {
+      panel.style.removeProperty('height');
+    } else {
+      const rows = Object.keys(isFiltering() ? filteredContent : fullPageContent).length;
+      const lineHeight = getDefaultDivHeightValue();
+      panel.style.height = `${rows * lineHeight}px`;
+    }
+  }
 
 function changeVisibilityAfterRun() {
     if (getDestinationValue() === 'Terminal') {
@@ -311,6 +323,7 @@ function clear() {
         resetContent();
         resetFilter();
     }
+    setHeightContentPanel(true);
     emptyContent();
 }
 
@@ -339,6 +352,7 @@ function updateContent(newContent) {
     }
 
     content = saveFilteredContent(content);
+    setHeightContentPanel();
     renderByPagination(content);
     switchClass('clearBtn', 'display-none', 'display-inline-block');
 }


### PR DESCRIPTION
When viewing pod logs in the Webview:

- The **Scroll to Bottom** button is inconsistent and fails once logs exceed the pagination threshold.  
- Manually scrolling enters an infinite‐load loop and never actually reaches the end.

Observed behavior: 

https://github.com/user-attachments/assets/320fa605-328e-4d76-923f-e8661ff2569b


Fixed behavior: 

https://github.com/user-attachments/assets/1249c9e0-f46e-4632-9c3f-da9c6b94e8cf



Fixes issues: https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1368, https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1226, https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1220 & https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1135

Reintroduced a refactored `setHeightContentPanel()` helper that properly restores the container's height before each render. This fixes the true location of the bottom anchor which in turn resolves both bugs.

**.vsix for testing:** [vscode-kubernetes-tools-1.3.22-logfix.vsix.zip](https://github.com/user-attachments/files/19854602/vscode-kubernetes-tools-1.3.22-logfix.vsix.zip)
