### PR TITLE
[Fix] Error with 'Set kubeconfig'

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2042,19 +2042,16 @@ async function createClusterKubernetes() {
 
 const ADD_NEW_KUBECONFIG_PICK = "+ Add new kubeconfig";
 
-async function useKubeconfigKubernetes(kubeconfig?: string | { isTrusted: boolean } /* TODO: remove when VS Code fixed */): Promise<void> {
-    // TODO: remove when VS Code fixed - workaround for https://github.com/microsoft/vscode/issues/94872
-    function fix94872(kubeconfig?: string | { isTrusted: boolean }): string | undefined {
-        function isBuggyThing(o: string | undefined | { isTrusted: boolean }): o is { isTrusted: boolean } {
-            return !!o && ((o as any).isTrusted !== undefined);
-        }
-        if (isBuggyThing(kubeconfig)) {
-            return undefined;
-        }
-        return kubeconfig;
+async function useKubeconfigKubernetes(kubeconfig?: string): Promise<void> {
+    // prevents miscelanneous context arguments from being processed
+    let kubeconfigPath: string | undefined;
+    if (typeof kubeconfig !== 'string') {
+        kubeconfigPath = undefined;
+    } else {
+        kubeconfigPath = kubeconfig;
     }
 
-    const kc = await getKubeconfigSelection(fix94872(kubeconfig));
+    const kc = await getKubeconfigSelection(kubeconfigPath);
     if (!kc) {
         return;
     }


### PR DESCRIPTION
This PR fixes an issue where setting a new kubeconfig via the context menu would throw an error. The root cause was outdated logic that attempted to handle arbitrary contextual arguments passed by older versions of VS Code. This logic is no longer necessary and was interfering with expected behavior—specifically, it failed to properly differentiate between a context object and a valid kubeconfig path. The function has been updated to safely ignore irrelevant contextual arguments and prevent this error.

**Observed behavior**

https://github.com/user-attachments/assets/a0af1553-c29e-4342-b042-00026c686192


**Fixes Issues**
- #1509
- https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1115

.vsix for testing: [vscode-kubernetes-tools-1.3.22-kubeconfigfix.vsix.zip](https://github.com/user-attachments/files/19868518/vscode-kubernetes-tools-1.3.22-kubeconfigfix.vsix.zip)

