### PR TITLE
Updating regex for aks cluster detection

### DIFF
--- a/src/kubectlUtils.ts
+++ b/src/kubectlUtils.ts
@@ -116,7 +116,7 @@ export async function getContexts(kubectl: Kubectl, options: ConfigReadOptions):
     const cluster = clusters.find((cl) => cl.name === c.context.cluster);
 
     // Extract provider type from the cluster's server property if it includes "azk8ms"
-    const azurePattern = /(^|\.)azmk8s\.io(?=$|\/|\?)/i;
+    const azurePattern = /(^|\.)azmk8s\.io(?=[:\/?]|$)/i;
     const provider = azurePattern.test(cluster?.cluster?.server || '') ? 'AKS' : '';
 
     return {

--- a/src/telemetry-helper.ts
+++ b/src/telemetry-helper.ts
@@ -158,8 +158,8 @@ async function inferCurrentClusterType(kubectl: Kubectl): Promise<[ClusterType, 
     }
 
     const masterInfo = masterInfos[0];
-    const azurePattern = /(^|\.)azmk8s\.io(?=$|\/|\?)/i;
-    const azureComPattern = /(^|\.)azure\.com(?=$|\/|\?)/i;
+    const azurePattern = /(^|\.)azmk8s\.io(?=[:\/?]|$)/i;
+    const azureComPattern = /(^|\.)azmk8s\.com(?=[:\/?]|$)/i;
 
     if (azurePattern.test(masterInfo) || azureComPattern.test(masterInfo)) {
         return [ClusterType.Azure, NonDeterminationReason.None];


### PR DESCRIPTION
AKS clusters were not being correctly identified by the extension due to the presence of a trailing colon and port number in the server URL. This update modifies the regex to account for port numbers, if applicable.