### PR TITLE
Adding check for kubeconfig file path existence

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2077,7 +2077,25 @@ async function useKubeconfigKubernetes(kubeconfig?: string): Promise<void> {
     }
 
     const kc = await getKubeconfigSelection(kubeconfigPath);
+    // return if no selection was made
     if (!kc) {
+        return;
+    }
+    // check to see if kubeconfig file path exists
+    if (!fs.existsSync(kc)) {
+        // prompts user to remove the entry from known configs
+        const removePick = await vscode.window.showWarningMessage(
+            `Kubeconfig file not found at path: ${kc}. Do you want to remove this entry from your known configs?`,
+            'Yes', 'No'
+        );
+        
+        // if user chooses to remove the entry, remove it from known configs
+        if (removePick === 'Yes') {
+            const knownKubeconfigs = getKnownKubeconfigs();
+            const updatedKubeconfigs = knownKubeconfigs.filter(path => path !== kc);
+            config.setConfigValue('vs-kubernetes.knownKubeconfigs', updatedKubeconfigs);
+            vscode.window.showInformationMessage(`Removed invalid kubeconfig from settings.`);
+        }
         return;
     }
     await setActiveKubeconfig(kc);


### PR DESCRIPTION
When users switch machines, their kubeconfig file paths come with them through their VS Code settings. If a path doesn’t exist on the new machine, there's currently no feedback — the clusters view just stays empty. This can confuse users into thinking their kubeconfig is broken or that something else in the extension isn’t working, which a few users have reported.

This update shows a clear message when a selected kubeconfig file is missing, and also provides a button to easily remove the invalid path from the user’s known kubeconfigs.

Fixes issue: 
- https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1237 


.vsix: [vscode-kubernetes-tools-1.3.23-testkc.vsix.zip](https://github.com/user-attachments/files/20106725/vscode-kubernetes-tools-1.3.23-testkc.vsix.zip)

