### PR TITLE
Enabling search functionality in Log Webviews

### DIFF
--- a/src/components/webpanel/webpanel.ts
+++ b/src/components/webpanel/webpanel.ts
@@ -19,6 +19,7 @@ export abstract class WebPanel {
         const panel = vscode.window.createWebviewPanel(viewType, title, column || vscode.ViewColumn.One, {
             enableScripts: true,
             retainContextWhenHidden: true,
+            enableFindWidget: true,
             // And restrict the webview to only loading content from our extension's `media` directory.
             localResourceRoots
         });


### PR DESCRIPTION
This PR enables built-in `Ctrl + F` search in the Logs Webview by setting `enableFindWidget` to `true`. This helps users out with an additional tool to assist when investigating logs in the webview. 

Related issues: 
- https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1196
- https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1241

.vsix: [vscode-kubernetes-tools-1.3.23-find.vsix.zip](https://github.com/user-attachments/files/20108314/vscode-kubernetes-tools-1.3.23-find.vsix.zip)
