### PR TITLE
Work to remove deprecated request package.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
                 "lodash": "^4.17.21",
                 "mkdirp": "^3.0.1",
                 "moment": "^2.30.1",
+                "node-fetch": "^3.3.2",
                 "node-yaml-parser": "^0.0.9",
                 "opn": "^6.0.0",
                 "pluralize": "^8.0.0",
@@ -48,6 +49,7 @@
                 "@types/mkdirp": "^2.0.0",
                 "@types/mocha": "^10.0.10",
                 "@types/node": "^22.15.17",
+                "@types/node-fetch": "^2.6.12",
                 "@types/pluralize": "^0.0.33",
                 "@types/request": "^2.48.12",
                 "@types/semver": "^7.7.0",
@@ -1023,6 +1025,26 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/@kubernetes/client-node/node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@kubernetes/client-node/node_modules/tar-fs": {
             "version": "3.0.8",
             "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
@@ -1116,30 +1138,30 @@
             }
         },
         "node_modules/@secretlint/config-creator": {
-            "version": "9.3.3",
-            "resolved": "https://registry.npmjs.org/@secretlint/config-creator/-/config-creator-9.3.3.tgz",
-            "integrity": "sha512-USIKXtBIDPBt+uxssxFVqYBzSommdwXNDGwRZPGErnKWeIH58XuyqIjRTi99fYB0yAQZZ+Cv4sD2JVXCxevEew==",
+            "version": "9.3.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/config-creator/-/config-creator-9.3.2.tgz",
+            "integrity": "sha512-IDUNnM/WVYcvj9PeoZIAvew31HHOtL/paJVkYT2D7G8HyehhTOPMvZSYVr43KXZ/bwUdlJg39C14xPx0NVsJyw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@secretlint/types": "^9.3.3"
+                "@secretlint/types": "^9.3.2"
             },
             "engines": {
                 "node": "^14.13.1 || >=16.0.0"
             }
         },
         "node_modules/@secretlint/config-loader": {
-            "version": "9.3.3",
-            "resolved": "https://registry.npmjs.org/@secretlint/config-loader/-/config-loader-9.3.3.tgz",
-            "integrity": "sha512-t0NGpVq7fFROr/UqfxSI09UI30U7rKSGXjfKNwR0O6fMlwx2AV9RWOvLS4hDLwxxKs+ywss6DZx/wcTdtBEWxA==",
+            "version": "9.3.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/config-loader/-/config-loader-9.3.2.tgz",
+            "integrity": "sha512-5pBUiAFI7lwHzsxPozwhIXVVxj65MbPOth5nSPz2rdpLg/dlti3udlstoq624kqQAlpb196Bhto3JCZGpKduQw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@secretlint/profiler": "^9.3.3",
-                "@secretlint/resolver": "^9.3.3",
-                "@secretlint/types": "^9.3.3",
+                "@secretlint/profiler": "^9.3.2",
+                "@secretlint/resolver": "^9.3.2",
+                "@secretlint/types": "^9.3.2",
                 "ajv": "^8.17.1",
-                "debug": "^4.4.1",
+                "debug": "^4.4.0",
                 "rc-config-loader": "^4.1.3"
             },
             "engines": {
@@ -1171,15 +1193,15 @@
             "license": "MIT"
         },
         "node_modules/@secretlint/core": {
-            "version": "9.3.3",
-            "resolved": "https://registry.npmjs.org/@secretlint/core/-/core-9.3.3.tgz",
-            "integrity": "sha512-XPpchOJz591E6bqMWkY6VxtaIbSI0gY0bUeVz1gkfT6FUI0fOfJrAMWe9RhxXWraMuxokTQA8R/LFJefiK+bXg==",
+            "version": "9.3.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/core/-/core-9.3.2.tgz",
+            "integrity": "sha512-oBsrFDTwXvFNLjIdcwrbCS/WUhKrGUeTDTSrmQBuaJvLHgCUX8/jEuBhBONkUDgWO3QEHRhi9LDlgnBqTIODEw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@secretlint/profiler": "^9.3.3",
-                "@secretlint/types": "^9.3.3",
-                "debug": "^4.4.1",
+                "@secretlint/profiler": "^9.3.2",
+                "@secretlint/types": "^9.3.2",
+                "debug": "^4.4.0",
                 "structured-source": "^4.0.0"
             },
             "engines": {
@@ -1187,19 +1209,19 @@
             }
         },
         "node_modules/@secretlint/formatter": {
-            "version": "9.3.3",
-            "resolved": "https://registry.npmjs.org/@secretlint/formatter/-/formatter-9.3.3.tgz",
-            "integrity": "sha512-kqfnbhtxcH1Ew7pboM+jCZl8CuBzVuEKuHHSkT92iasxaaq1NK37h5IIfUDbFdXizmNFe3MwAnnVU8lqK2Dvyg==",
+            "version": "9.3.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/formatter/-/formatter-9.3.2.tgz",
+            "integrity": "sha512-JiFhZtg2a4WdkPxCXlq0iGUz18UxzjWnyUMvb/89BvF5m9DKDvmlfHIMLZ3O5205mSJqlpcZxRu7eADJB9fS7Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@secretlint/resolver": "^9.3.3",
-                "@secretlint/types": "^9.3.3",
-                "@textlint/linter-formatter": "^14.7.1",
-                "@textlint/module-interop": "^14.7.1",
-                "@textlint/types": "^14.7.1",
+                "@secretlint/resolver": "^9.3.2",
+                "@secretlint/types": "^9.3.2",
+                "@textlint/linter-formatter": "^14.6.0",
+                "@textlint/module-interop": "^14.6.0",
+                "@textlint/types": "^14.6.0",
                 "chalk": "^4.1.2",
-                "debug": "^4.4.1",
+                "debug": "^4.4.0",
                 "pluralize": "^8.0.0",
                 "strip-ansi": "^6.0.1",
                 "table": "^6.9.0",
@@ -1210,19 +1232,19 @@
             }
         },
         "node_modules/@secretlint/node": {
-            "version": "9.3.3",
-            "resolved": "https://registry.npmjs.org/@secretlint/node/-/node-9.3.3.tgz",
-            "integrity": "sha512-ZD1yXlzEJmFS/lq+BmgzUBB+2mQgj6kK6A//IhBop5xqAp+lXoq1vNgu7VSJ3DR+XrKrIK7YHFZXRh9aJvIjmA==",
+            "version": "9.3.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/node/-/node-9.3.2.tgz",
+            "integrity": "sha512-WH3PjYtZ8RumUJFZvM4vYEvpelT2m6WFzCRS3j+nzmH5eSv70+BWSISMB/ouZ5koq1+1zPlnWf/ADEvOwgbebw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@secretlint/config-loader": "^9.3.3",
-                "@secretlint/core": "^9.3.3",
-                "@secretlint/formatter": "^9.3.3",
-                "@secretlint/profiler": "^9.3.3",
-                "@secretlint/source-creator": "^9.3.3",
-                "@secretlint/types": "^9.3.3",
-                "debug": "^4.4.1",
+                "@secretlint/config-loader": "^9.3.2",
+                "@secretlint/core": "^9.3.2",
+                "@secretlint/formatter": "^9.3.2",
+                "@secretlint/profiler": "^9.3.2",
+                "@secretlint/source-creator": "^9.3.2",
+                "@secretlint/types": "^9.3.2",
+                "debug": "^4.4.0",
                 "p-map": "^4.0.0"
             },
             "engines": {
@@ -1230,16 +1252,16 @@
             }
         },
         "node_modules/@secretlint/profiler": {
-            "version": "9.3.3",
-            "resolved": "https://registry.npmjs.org/@secretlint/profiler/-/profiler-9.3.3.tgz",
-            "integrity": "sha512-wcVTByh+m9O1w2WAV08Po6trGsVjhRTV1UWuzVcQTTap9EjeKQLja6Xof/SIDGORD0KWooUIMAe7VPLQFPi1cQ==",
+            "version": "9.3.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/profiler/-/profiler-9.3.2.tgz",
+            "integrity": "sha512-cXXWQzA6lIcT0TY53JvbXtH6BltBfqmH5V39byhnbDfZl5FKCB6FHxVVzkctjwss6KMtDXcNLvfz3nKBZaWRDA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@secretlint/resolver": {
-            "version": "9.3.3",
-            "resolved": "https://registry.npmjs.org/@secretlint/resolver/-/resolver-9.3.3.tgz",
-            "integrity": "sha512-8N0lqD7OiI/aLK/PhKyiGh5xTlO/6TjHiOt72jnrvB9BK2QF45Mp5fivCARTKBypDiTZrOrS7blvqZ7qTnOTrA==",
+            "version": "9.3.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/resolver/-/resolver-9.3.2.tgz",
+            "integrity": "sha512-yOi6md3kzpaFw6w2FJTDLoKlUxr1RltBJrb5lheIBDDXy/7C/5gP0K4uMiqamnVg8c9Ac+qlNS5KUar8FDFpdg==",
             "dev": true,
             "license": "MIT"
         },
@@ -1277,13 +1299,13 @@
             }
         },
         "node_modules/@secretlint/source-creator": {
-            "version": "9.3.3",
-            "resolved": "https://registry.npmjs.org/@secretlint/source-creator/-/source-creator-9.3.3.tgz",
-            "integrity": "sha512-2h6t9UfWQn7Sp6PUO+hvWK3i55tqE4H4YlmUBlL5VOjubADcO21OAtp7S05LgXE+VJfLDgUcb1hflkw0cPE1rw==",
+            "version": "9.3.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/source-creator/-/source-creator-9.3.2.tgz",
+            "integrity": "sha512-eEP8sHnTB7rtv976Awh5+VMTD8udiHBaeSWAEKGy21Gas/slEb02Q812SWo2UMX9NcVBl+DYaOkmPQbcPHrY5A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@secretlint/types": "^9.3.3",
+                "@secretlint/types": "^9.3.2",
                 "istextorbinary": "^6.0.0"
             },
             "engines": {
@@ -1291,9 +1313,9 @@
             }
         },
         "node_modules/@secretlint/types": {
-            "version": "9.3.3",
-            "resolved": "https://registry.npmjs.org/@secretlint/types/-/types-9.3.3.tgz",
-            "integrity": "sha512-ehVGggPM23sHEkqQP/5HlGDK+8Xx2oRX8vF9C/fKh+TcTRWOfjCeC7QeoPxcEMXNDXfUsHK5P8DKqQEcpbiUZQ==",
+            "version": "9.3.2",
+            "resolved": "https://registry.npmjs.org/@secretlint/types/-/types-9.3.2.tgz",
+            "integrity": "sha512-Mxs8jzyPm843B0P/YNiOxnFSNyYtrmMoLPjrmqebrI5LBERRGctXj2Q9Oy/ayZ+FMK+1cP9jLhceicRvlZPR1Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1803,16 +1825,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.32.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.32.1.tgz",
-            "integrity": "sha512-LKMrmwCPoLhM45Z00O1ulb6jwyVr2kr3XJp+G+tSEZcbauNnScewcQwtJqXDhXeYPDEjZ8C1SjXm015CirEmGg==",
+            "version": "8.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.33.0.tgz",
+            "integrity": "sha512-JaehZvf6m0yqYp34+RVnihBAChkqeH+tqqhS0GuX1qgPpwLvmTPheKEs6OeCK6hVJgXZHJ2vbjnC9j119auStQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.32.1",
-                "@typescript-eslint/types": "8.32.1",
-                "@typescript-eslint/typescript-estree": "8.32.1",
-                "@typescript-eslint/visitor-keys": "8.32.1",
+                "@typescript-eslint/scope-manager": "8.33.0",
+                "@typescript-eslint/types": "8.33.0",
+                "@typescript-eslint/typescript-estree": "8.33.0",
+                "@typescript-eslint/visitor-keys": "8.33.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1825,6 +1847,131 @@
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
                 "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+            "version": "8.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.33.0.tgz",
+            "integrity": "sha512-LMi/oqrzpqxyO72ltP+dBSP6V0xiUb4saY7WLtxSfiNEBI8m321LLVFU9/QDJxjDQG9/tjSqKz/E3380TEqSTw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.33.0",
+                "@typescript-eslint/visitor-keys": "8.33.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+            "version": "8.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.33.0.tgz",
+            "integrity": "sha512-DKuXOKpM5IDT1FA2g9x9x1Ug81YuKrzf4mYX8FAVSNu5Wo/LELHWQyM1pQaDkI42bX15PWl0vNPt1uGiIFUOpg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.33.0.tgz",
+            "integrity": "sha512-vegY4FQoB6jL97Tu/lWRsAiUUp8qJTqzAmENH2k59SJhw0Th1oszb9Idq/FyyONLuNqT1OADJPXfyUNOR8SzAQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/project-service": "8.33.0",
+                "@typescript-eslint/tsconfig-utils": "8.33.0",
+                "@typescript-eslint/types": "8.33.0",
+                "@typescript-eslint/visitor-keys": "8.33.0",
+                "debug": "^4.3.4",
+                "fast-glob": "^3.3.2",
+                "is-glob": "^4.0.3",
+                "minimatch": "^9.0.4",
+                "semver": "^7.6.0",
+                "ts-api-utils": "^2.1.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.33.0.tgz",
+            "integrity": "sha512-7RW7CMYoskiz5OOGAWjJFxgb7c5UNjTG292gYhWeOAcFmYCtVCSqjqSBj5zMhxbXo2JOW95YYrUWJfU0zrpaGQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.33.0",
+                "eslint-visitor-keys": "^4.2.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+            "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/project-service": {
+            "version": "8.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.33.0.tgz",
+            "integrity": "sha512-d1hz0u9l6N+u/gcrk6s6gYdl7/+pp8yHheRTqP6X5hVDKALEaTn8WfGiit7G511yueBEL3OpOEpD+3/MBdoN+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.33.0",
+                "@typescript-eslint/types": "^8.33.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/project-service/node_modules/@typescript-eslint/types": {
+            "version": "8.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.33.0.tgz",
+            "integrity": "sha512-DKuXOKpM5IDT1FA2g9x9x1Ug81YuKrzf4mYX8FAVSNu5Wo/LELHWQyM1pQaDkI42bX15PWl0vNPt1uGiIFUOpg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
@@ -1843,6 +1990,23 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.33.0.tgz",
+            "integrity": "sha512-sTkETlbqhEoiFmGr1gsdq5HyVbSOF0145SYDJ/EQmXHtKViCaGvnyLqWFFHtEXoS0J1yU8Wyou2UGmgW88fEug==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
@@ -2763,6 +2927,7 @@
             "version": "0.2.6",
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
             "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+            "license": "MIT",
             "dependencies": {
                 "safer-buffer": "~2.1.0"
             }
@@ -2771,6 +2936,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
             "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.8"
             }
@@ -2835,14 +3001,16 @@
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
             "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+            "license": "Apache-2.0",
             "engines": {
                 "node": "*"
             }
         },
         "node_modules/aws4": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
-            "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+            "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+            "license": "MIT"
         },
         "node_modules/azure-devops-node-api": {
             "version": "12.5.0",
@@ -2975,6 +3143,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "tweetnacl": "^0.14.3"
             }
@@ -3268,7 +3437,8 @@
         "node_modules/caseless": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
+            "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+            "license": "Apache-2.0"
         },
         "node_modules/chainsaw": {
             "version": "0.1.0",
@@ -3807,6 +3977,7 @@
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+            "license": "MIT",
             "dependencies": {
                 "assert-plus": "^1.0.0"
             },
@@ -3814,10 +3985,19 @@
                 "node": ">=0.10"
             }
         },
+        "node_modules/data-uri-to-buffer": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+            "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
         "node_modules/debug": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -3965,9 +4145,9 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.2.5",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.5.tgz",
-            "integrity": "sha512-mLPd29uoRe9HpvwP2TxClGQBzGXeEC/we/q+bFlmPPmj2p2Ugl3r6ATu/UU1v77DXNcehiBg9zsr1dREyA/dJQ==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+            "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
@@ -4041,6 +4221,7 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
             "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+            "license": "MIT",
             "dependencies": {
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.1.0"
@@ -4646,7 +4827,8 @@
             "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
             "engines": [
                 "node >=0.6.0"
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/fancy-log": {
             "version": "1.3.3",
@@ -4752,6 +4934,29 @@
             "dev": true,
             "dependencies": {
                 "pend": "~1.2.0"
+            }
+        },
+        "node_modules/fetch-blob": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+            "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "node-domexception": "^1.0.0",
+                "web-streams-polyfill": "^3.0.3"
+            },
+            "engines": {
+                "node": "^12.20 || >= 14.13"
             }
         },
         "node_modules/file-entry-cache": {
@@ -4924,6 +5129,7 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
             "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+            "license": "Apache-2.0",
             "engines": {
                 "node": "*"
             }
@@ -4942,6 +5148,18 @@
             },
             "engines": {
                 "node": ">= 0.12"
+            }
+        },
+        "node_modules/formdata-polyfill": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+            "license": "MIT",
+            "dependencies": {
+                "fetch-blob": "^3.1.2"
+            },
+            "engines": {
+                "node": ">=12.20.0"
             }
         },
         "node_modules/fs-constants": {
@@ -5157,6 +5375,7 @@
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+            "license": "MIT",
             "dependencies": {
                 "assert-plus": "^1.0.0"
             }
@@ -5468,6 +5687,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
             "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+            "license": "ISC",
             "engines": {
                 "node": ">=4"
             }
@@ -5477,6 +5697,7 @@
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
             "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
             "deprecated": "this library is no longer supported",
+            "license": "MIT",
             "dependencies": {
                 "ajv": "^6.12.3",
                 "har-schema": "^2.0.0"
@@ -5662,6 +5883,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+            "license": "MIT",
             "dependencies": {
                 "assert-plus": "^1.0.0",
                 "jsprim": "^1.2.2",
@@ -6012,7 +6234,8 @@
         "node_modules/is-typedarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+            "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+            "license": "MIT"
         },
         "node_modules/is-unc-path": {
             "version": "1.0.0",
@@ -6099,7 +6322,8 @@
         "node_modules/isstream": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
+            "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+            "license": "MIT"
         },
         "node_modules/istextorbinary": {
             "version": "6.0.0",
@@ -6214,7 +6438,8 @@
         "node_modules/jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+            "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
+            "license": "MIT"
         },
         "node_modules/jsep": {
             "version": "1.4.0",
@@ -6240,7 +6465,8 @@
         "node_modules/json-schema": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-            "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+            "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+            "license": "(AFL-2.1 OR BSD-3-Clause)"
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
@@ -6256,7 +6482,8 @@
         "node_modules/json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+            "license": "ISC"
         },
         "node_modules/json5": {
             "version": "2.2.3",
@@ -6354,6 +6581,7 @@
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
             "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+            "license": "MIT",
             "dependencies": {
                 "assert-plus": "1.0.0",
                 "extsprintf": "1.3.0",
@@ -7284,24 +7512,42 @@
             "dev": true,
             "optional": true
         },
+        "node_modules/node-domexception": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+            "deprecated": "Use your platform's native DOMException instead",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "github",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.5.0"
+            }
+        },
         "node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+            "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
             "license": "MIT",
             "dependencies": {
-                "whatwg-url": "^5.0.0"
+                "data-uri-to-buffer": "^4.0.0",
+                "fetch-blob": "^3.1.4",
+                "formdata-polyfill": "^4.0.10"
             },
             "engines": {
-                "node": "4.x || >=6.0.0"
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/node-fetch"
             }
         },
         "node_modules/node-releases": {
@@ -7416,6 +7662,7 @@
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
             "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+            "license": "Apache-2.0",
             "engines": {
                 "node": "*"
             }
@@ -8035,7 +8282,8 @@
         "node_modules/performance-now": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+            "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+            "license": "MIT"
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
@@ -8206,9 +8454,16 @@
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
         "node_modules/psl": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-            "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+            "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/lupomontero"
+            }
         },
         "node_modules/pump": {
             "version": "3.0.0",
@@ -8240,6 +8495,7 @@
             "version": "6.5.3",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
             "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.6"
             }
@@ -8436,6 +8692,7 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
             "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
             "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+            "license": "Apache-2.0",
             "dependencies": {
                 "aws-sign2": "~0.7.0",
                 "aws4": "^1.8.0",
@@ -8466,6 +8723,7 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
             "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+            "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.6",
@@ -8677,17 +8935,17 @@
             }
         },
         "node_modules/secretlint": {
-            "version": "9.3.3",
-            "resolved": "https://registry.npmjs.org/secretlint/-/secretlint-9.3.3.tgz",
-            "integrity": "sha512-JTIsI8BEon8Oo6P7YvGq3I3qCZuYgCvekU8qr4OYyvo6N/wHGg4JMruT5MVkxh3q0diX11xsqaptmeTP5/wNxQ==",
+            "version": "9.3.2",
+            "resolved": "https://registry.npmjs.org/secretlint/-/secretlint-9.3.2.tgz",
+            "integrity": "sha512-IuFrtWMGeVFSWpuhn1T6JC0mgfwD9rbFNZG1aWtpkBKOUCbcKZ+RoJcJjdJ0DXv8oa9vRg/+DZUl6Q6omZdPQQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@secretlint/config-creator": "^9.3.3",
-                "@secretlint/formatter": "^9.3.3",
-                "@secretlint/node": "^9.3.3",
-                "@secretlint/profiler": "^9.3.3",
-                "debug": "^4.4.1",
+                "@secretlint/config-creator": "^9.3.2",
+                "@secretlint/formatter": "^9.3.2",
+                "@secretlint/node": "^9.3.2",
+                "@secretlint/profiler": "^9.3.2",
+                "debug": "^4.4.0",
                 "globby": "^14.1.0",
                 "read-pkg": "^8.1.0"
             },
@@ -9122,6 +9380,7 @@
             "version": "1.18.0",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
             "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+            "license": "MIT",
             "dependencies": {
                 "asn1": "~0.2.3",
                 "assert-plus": "^1.0.0",
@@ -9720,6 +9979,7 @@
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
             "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "psl": "^1.1.28",
                 "punycode": "^2.1.1"
@@ -10040,7 +10300,8 @@
         "node_modules/tweetnacl": {
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
+            "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+            "license": "Unlicense"
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -10277,6 +10538,7 @@
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
             "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
             "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+            "license": "MIT",
             "bin": {
                 "uuid": "bin/uuid"
             }
@@ -10317,6 +10579,7 @@
             "engines": [
                 "node >=0.6.0"
             ],
+            "license": "MIT",
             "dependencies": {
                 "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
@@ -10326,7 +10589,8 @@
         "node_modules/verror/node_modules/core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
+            "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+            "license": "MIT"
         },
         "node_modules/vinyl": {
             "version": "3.0.0",
@@ -10476,6 +10740,15 @@
                 "node": ">=10.13.0"
             }
         },
+        "node_modules/web-streams-polyfill": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+            "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/webidl-conversions": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -10535,6 +10808,7 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
             "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.6.1",
                 "@webpack-cli/configtest": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1269,11 +1269,13 @@
         "compare-versions": "^6.1.1",
         "docker-file-parser": "^1.0.7",
         "dockerfile-parse": "^0.2.0",
+        "dompurify": "^3.2.4",
         "fuzzysearch": "^1.0.3",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
         "mkdirp": "^3.0.1",
         "moment": "^2.30.1",
+        "node-fetch": "^3.3.2",
         "node-yaml-parser": "^0.0.9",
         "opn": "^6.0.0",
         "pluralize": "^8.0.0",
@@ -1289,8 +1291,7 @@
         "vscode-extension-telemetry": "^0.4.5",
         "vscode-uri": "^3.1.0",
         "yaml-ast-parser": "^0.0.43",
-        "yamljs": "^0.3.0",
-        "dompurify": "^3.2.4"
+        "yamljs": "^0.3.0"
     },
     "devDependencies": {
         "@bendera/vscode-webview-elements": "^0.17.2",
@@ -1300,6 +1301,7 @@
         "@types/mkdirp": "^2.0.0",
         "@types/mocha": "^10.0.10",
         "@types/node": "^22.15.17",
+        "@types/node-fetch": "^2.6.12",
         "@types/pluralize": "^0.0.33",
         "@types/request": "^2.48.12",
         "@types/semver": "^7.7.0",

--- a/src/explainer.ts
+++ b/src/explainer.ts
@@ -16,7 +16,7 @@ export async function readSwagger(): Promise<SwaggerModel | undefined> {
     return readSwaggerCore(await loadKubeconfig());
 }
 
-export async function readSwaggerCore(kc: kubernetes.KubeConfig): Promise<any | undefined> {
+export async function readSwaggerCore(kc: kubernetes.KubeConfig): Promise<SwaggerModel | undefined> {
   const currentCluster = kc.getCurrentCluster();
   if (!currentCluster) return undefined;
 
@@ -41,7 +41,7 @@ export async function readSwaggerCore(kc: kubernetes.KubeConfig): Promise<any | 
     }
 
     const json = await res.json();
-    return json;
+    return json as SwaggerModel;
   } catch (error: any) {
     console.error("Failed to fetch swagger.json:", error.message);
     throw error;


### PR DESCRIPTION
This work is for removing decprecated `request` package and replace it with `node-fetch`, intern this will help in fixing: https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/security/dependabot/18 and https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/security/dependabot/17 

Thanks heaps and gentle fyi to @tejhan and @squillace ❤️ 

I have tested this change in my local and it had no adverse effect into existing aspect, but in longer run we should think of re-accessing the need of explainer.ts and might be our yaml extension dependency is enough to handle the help hover text.

Thank you so much and here is vsix for playing around.

[vscode-kubernetes-tools-1.3.23-test-pkg-deprecation.vsix.zip](https://github.com/user-attachments/files/20377654/vscode-kubernetes-tools-1.3.23-test-pkg-deprecation.vsix.zip)

