### PR TITLE
Adding kebabcase template function to helm linter

### DIFF
--- a/src/helm.funcmap.ts
+++ b/src/helm.funcmap.ts
@@ -111,6 +111,7 @@ export class FuncMap {
             // 2.12.0
             this.f("snakecase", "snakecase $str", "Convert $str to snake_case"),
             this.f("camelcase", "camelcase $str", "convert string to camelCase"),
+            this.f("kebabcase", "kebabcase $str", "convert string to kebab-case"),
             this.f("shuffle", "shuffle $str", "randomize a string"),
             this.f("fail", `fail $msg`, "cause the template render to fail with a message $msg."),
 


### PR DESCRIPTION
This PR adds support for the `kebabcase` template function to the Helm linter, enabling proper recognition, IntelliSense, & hover documentation.

Fixes issue: 
- https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1544

.vsix: [vscode-kubernetes-tools-1.3.23-kebabtest.vsix.zip](https://github.com/user-attachments/files/20592437/vscode-kubernetes-tools-1.3.23-kebabtest.vsix.zip)
