### PR TITLE
Fix: Remove extra newlines in block comment config for proper toggle support

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -3,7 +3,7 @@
         // comments applicable to yaml files.
         "lineComment": "#",
         // comments applicable to tpl files.
-        "blockComment": [ "{{- /*\n", "\n*/ -}}" ]
+        "blockComment": [ "{{- /*", "*/ }}" ]
     },
     // symbols used as brackets
     "brackets": [


### PR DESCRIPTION
This PR updates the blockComment configuration for Helm templates:

The previous configuration inserted newline characters, which broke the ability to cleanly toggle block comments using Shift + Alt + A. This fix removes the extra newlines, restoring proper toggle behavior.

Fixes issue:
- https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1243


Observed behavior (improper toggling):

https://github.com/user-attachments/assets/b7d6f9d3-d153-402f-9c41-25d3fd151198

Fixed behavior (proper toggling):

https://github.com/user-attachments/assets/4156db83-75b8-4cfb-8e20-a5de850f904a

.vsix: 
[vscode-kubernetes-tools-1.3.23-commentfix.vsix.zip](https://github.com/user-attachments/files/20596592/vscode-kubernetes-tools-1.3.23-commentfix.vsix.zip)


