### PR TITLE
Publish release 1.3.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Change Log
 
+## [1.3.24]
+
+* Dependabot PRs
+* Alignment and visual feedback fixes (#1527)
+* Enabling find widget (#1536)
+* Add check for kconfig file path existence (#1535)
+* Add project CNCF logo for this project. (#1537)
+* Update vscode engine and package. (#1538)
+* Remove invalid badge. (#1550)
+* Removing deprecated download package (#1515)
+* Work to remove deprecated request package. (#1552)
+* fixing gotemplate block comments for toggleability (#1566)
+* Added kebabcase recognition to linter (#1565)
+* updating tar-fs & removing request package (#1575)
+
+Contributors: Contributions and Reviews to tejhan, bosesuneha, davidgamero, ReinierCC, qpetraroia Thank you all!!
+
 ## [1.3.23]
 
 * Dependabot PRs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-kubernetes-tools",
-    "version": "1.3.23",
+    "version": "1.3.24",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-kubernetes-tools",
-            "version": "1.3.23",
+            "version": "1.3.24",
             "license": "Apache-2.0",
             "dependencies": {
                 "@azure/arm-containerservice": "^21.6.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-kubernetes-tools",
     "displayName": "Kubernetes",
     "description": "Develop, deploy and debug Kubernetes applications",
-    "version": "1.3.23",
+    "version": "1.3.24",
     "publisher": "ms-kubernetes-tools",
     "engines": {
         "vscode": "^1.99.1"


### PR DESCRIPTION
This PR is intended to open release for version `1.13.24` which carries following key things along with various dependant PR.

* Dependabot PRs
* Alignment and visual feedback fixes (#1527)
* Enabling find widget (#1536)
* Add check for kconfig file path existence (#1535)
* Add project CNCF logo for this project. (#1537)
* Update vscode engine and pacakge. (#1538)
* Remove invalid badge. (#1550)
* Removing deprecated download package (#1515)
* Work to remove deprecated request package. (#1552)
* fixing gotemplate block comments for toggleability (#1566)
* Added kebabcase recognition to linter (#1565)
* updating tar-fs & removing request package (#1575)


Thanks heaps, and ❤️ gentle fyi to (Lets please get this quick spin around windows and other O/S please)  @ReinierCC, @tejhan, @bosesuneha , @davidgamero &  @qpetraroia  ❤️ cc: @squillace , @gambtho

Please note we are aiming for midweek or end of this week release, thanks.

**VSIX for quick test:** 


[vscode-kubernetes-tools-1.3.24-test.vsix.zip](https://github.com/user-attachments/files/20681484/vscode-kubernetes-tools-1.3.24-test.vsix.zip)
