### PR TITLE
Use recommended Kubernetes metadata labels in snippets

### DIFF
--- a/snippets/ingress.yaml
+++ b/snippets/ingress.yaml
@@ -7,7 +7,7 @@ body: |2
   metadata:
     name: ${1:myingress}
     labels:
-      name: ${1:myingress}
+      app.kubernetes.io/name: ${1:myingress}
   spec:
     rules:
     - host: ${2:<Host>}

--- a/snippets/pod.yaml
+++ b/snippets/pod.yaml
@@ -7,7 +7,7 @@ body: |2
   metadata:
     name: ${1:myapp}
     labels:
-      name: ${1:myapp}
+      app.kubernetes.io/name: ${1:myapp}
   spec:
     containers:
     - name: ${1:myapp}


### PR DESCRIPTION
This PR updates the Kubernetes manifest snippets to use the <a target="_blank" href ="https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/"> recommended metadata label conventions</a>, specifically those prefixed with `app.kubernetes.io/`.

Closes issue:
- https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1479

fyi @Tatsinnit 