### PR TITLE
Adding kubeconfig validation & overwrite options

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -74,7 +74,7 @@ import { APIBroker } from './api/contract/api';
 import { apiBroker } from './api/implementation/apibroker';
 import { sleep } from './sleep';
 import { CloudExplorer, CloudExplorerTreeNode } from './components/cloudexplorer/cloudexplorer';
-import { mergeToKubeconfig, getKubeconfigPath, KubeconfigPath } from './components/kubectl/kubeconfig';
+import { mergeToKubeconfig, getKubeconfigPath, KubeconfigPath, validateKubeconfigPath } from './components/kubectl/kubeconfig';
 import { PortForwardStatusBarManager } from './components/kubectl/port-forward-ui';
 import { getBuildCommand, getPushCommand } from './image/imageUtils';
 import { getImageBuildTool } from './components/config/config';
@@ -133,6 +133,7 @@ export const HELM_TPL_MODE: vscode.DocumentFilter = { language: "helm", scheme: 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export async function activate(context: vscode.ExtensionContext): Promise<APIBroker> {
+    await validateKubeconfigPath();
     setAssetContext(context);
 
     await fixOldInstalledBinaryPermissions(shell);
@@ -2067,7 +2068,7 @@ async function createClusterKubernetes() {
 
 const ADD_NEW_KUBECONFIG_PICK = "+ Add new kubeconfig";
 
-async function useKubeconfigKubernetes(kubeconfig?: string): Promise<void> {
+export async function useKubeconfigKubernetes(kubeconfig?: string): Promise<void> {
     // prevents miscelanneous context arguments from being processed
     let kubeconfigPath: string | undefined;
     if (typeof kubeconfig !== 'string') {


### PR DESCRIPTION
This PR introduces a validation step for the active kubeconfig path. When the configured file cannot be found, the extension now alerts the user and offers to add or select a new kubeconfig. Before this change, invalid or missing kubeconfig paths caused the extension to fail silently, leaving the cluster tree view empty and users unaware that their configuration was the issue.

This update covers scenarios where users carry over a kubeconfig path from another machine and forget to update it, as well as cases where the extension falls back to default locations on a fresh install. In both situations, instead of showing a blank cluster menu, the extension will now prompt the user to correct their kubeconfig location immediately.

Related issues: 
#1333, #1334, #1418

(Note: these issues all have their own nuances but each has similar issue of not being notified when the actively set kubeconfig is non-existent.)

(This is a redo of PR #1567 that got build errors from faulty merge) (https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/pull/1567)