### PR TITLE
Detect real CPU arch on macOS to install correct binary

### DIFF
--- a/src/components/installer/installationlayout.ts
+++ b/src/components/installer/installationlayout.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 
 import { fs } from '../../fs';
 import { Platform, Shell } from "../../shell";
+import * as shelljs from 'shelljs';
 
 export function vsKubernetesFolder(shell: Shell): string {
     const originalDir = path.join(shell.home(), `.vs-kubernetes`);
@@ -52,6 +53,15 @@ export function formatBin(tool: string, platform: Platform): string | null {
 }
 
 export function platformArch(os: string) {
+    // on macOS ask the kernel directly
+    if (os === "darwin") {
+        try {
+            const arch = shelljs.exec("uname -m", { silent: true }).stdout.trim();
+            return arch === "arm64" ? "arm64" : "amd64";
+        } catch {
+      // fall-back to Node’s process.arch
+        }
+    }
     if (process.arch === 'arm' && os === 'linux') {
         return 'arm';
     } else if (process.arch === 'arm64') {


### PR DESCRIPTION
This PR fixes a bug where some Mac devices running under Rosetta (like M3 for example) were being seen as x64 via the `process.arch` function, causing the amd64 binary to be installed and fail at runtime. We now use `uname -m` on macOS to get the true architecture and ensure arm64 builds go to arm64 devices. It seems that some users had the incorrect binary silently installed, which causes a couple related errors. 

Addresses issue: 
- https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1360

.vsix: [vscode-kubernetes-tools-1.3.24-arch1.vsix.zip](https://github.com/user-attachments/files/21022357/vscode-kubernetes-tools-1.3.24-arch1.vsix.zip)
