### PR TITLE
Publish version 1.3.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [1.3.25]
+
+* Dependabot PRs
+* Use recommended Kubernetes metadata labels in snippets (#1577)
+* Fixing duplicate detection & adding overwrite option (#1564)
+* Adding check & replacement option for invalid active kubeconfig (#1567)
+
+Contributors: Contributions and Reviews to tejhan, bosesuneha, davidgamero, ReinierCC, qpetraroia Thank you all!!
+
 ## [1.3.24]
 
 * Dependabot PRs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-kubernetes-tools",
-    "version": "1.3.24",
+    "version": "1.3.25",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-kubernetes-tools",
-            "version": "1.3.24",
+            "version": "1.3.25",
             "license": "Apache-2.0",
             "dependencies": {
                 "@azure/arm-containerservice": "^21.6.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-kubernetes-tools",
     "displayName": "Kubernetes",
     "description": "Develop, deploy and debug Kubernetes applications",
-    "version": "1.3.24",
+    "version": "1.3.25",
     "publisher": "ms-kubernetes-tools",
     "engines": {
         "vscode": "^1.99.1"


### PR DESCRIPTION
This PR is intended to open release for version `1.13.25` which carries following key things along with various dependant PR.

* Dependabot PRs
* Use recommended Kubernetes metadata labels in snippets (#1577)
* Fixing duplicate detection & adding overwrite option (#1564)
* Adding check & replacement option for invalid active kubeconfig (#1567)


Thanks heaps, and ❤️ gentle fyi to (Lets please get this quick spin around windows and other O/S please)  @ReinierCC, @tejhan, @bosesuneha , @davidgamero &  @qpetraroia  ❤️ cc: @squillace , @gambtho

Please note we are aiming for midweek or end of this week release, thanks.

**VSIX for quick test:** 

[vscode-kubernetes-tools-1.3.25-test.vsix.zip](https://github.com/user-attachments/files/21009942/vscode-kubernetes-tools-1.3.25-test.vsix.zip)


