### PR TITLE
Adding option to disable unwanted Helm notifications

### DIFF
--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -332,6 +332,10 @@ export function suppressHelmNotFound(): boolean {
     return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.suppress-helm-not-found-alerts'];
 }
 
+export function setSuppressHelmNotFound(suppress:boolean):void{
+    setConfigValue('vs-kubernetes.suppress-helm-not-found-alerts', suppress);
+}
+
 export function ignoreK8sRecommendations(): boolean {
     return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.ignore-recommendations'];
 }


### PR DESCRIPTION
Users have reported receiving dependency alerts for tools they don’t use. This PR is part of a series of a couple smaller pr's to tackle a group of similar issues reported related to binary tooling, and in this case we need to have clear disable options at each binary tool’s discovery point & prevent premature invocation of tool discovery, alongside other niche errors and cases which will later be addressed as well.

This change adds a second action to the Helm-not-found notification to Disable Helm checks, essentially a “Do not notify again” button so non-Helm users can suppress future Helm checks without having to look for and edit specific JSON config settings manually.

Addresses issue:
- https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1252

.vsix: [vscode-kubernetes-tools-1.3.24-helmnoti.vsix.zip](https://github.com/user-attachments/files/21022314/vscode-kubernetes-tools-1.3.24-helmnoti.vsix.zip)