### PR TITLE
Removing outdated flag from watch command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1252,7 +1252,7 @@
         "compile": "npm run compile:ext && npm run compile:view",
         "compile:ext": "webpack --mode none",
         "compile:view": "webpack --mode none --config src/components/logs/webpack.config.js",
-        "watch": "webpack --mode development --watch --info-verbosity verbose",
+        "watch": "webpack --mode development --watch",
         "test-compile": "tsc -p ./",
         "test": "npm run test-compile && node ./out/test/runTest.js",
         "package": "vsce package"


### PR DESCRIPTION
Our `watch` script uses the `--info-verbosity verbose` tag which is no longer supported or recognized by webpack, causing the command to fail. 

This PR is simply removes that flag for a functioning watch script. Slight QOL improvement for devs.

