### PR TITLE
Move away from old telemetry package.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@azure/arm-containerservice": "^22.2.0",
                 "@kubernetes/client-node": "^1.3.0",
                 "@microsoft/vscode-azext-azureauth": "^4.2.0",
+                "@vscode/extension-telemetry": "^1.0.0",
                 "@vscode/test-electron": "^2.5.2",
                 "ansi-to-html": "^0.7.2",
                 "compare-versions": "^6.1.1",
@@ -35,7 +36,6 @@
                 "tar": "^7.4.3",
                 "tmp": "^0.2.5",
                 "unzipper": "^0.10.14",
-                "vscode-extension-telemetry": "^0.4.5",
                 "vscode-uri": "^3.1.0",
                 "yaml-ast-parser": "^0.0.43",
                 "yamljs": "^0.3.0"
@@ -1118,6 +1118,115 @@
                 "@lit-labs/ssr-dom-shim": "^1.0.0"
             }
         },
+        "node_modules/@microsoft/1ds-core-js": {
+            "version": "4.3.9",
+            "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-4.3.9.tgz",
+            "integrity": "sha512-T8s5qROH7caBNiFrUpN8vgC6wg7QysVPryZKprgl3kLQQPpoMFM6ffIYvUWD74KM9fWWLU7vzFFNBWDBsrTyWg==",
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/applicationinsights-core-js": "3.3.9",
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+                "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+            }
+        },
+        "node_modules/@microsoft/1ds-post-js": {
+            "version": "4.3.9",
+            "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-4.3.9.tgz",
+            "integrity": "sha512-BvxI4CW8Ws+gfXKy+Y/9pmEXp88iU1GYVjkUfqXP7La59VHARTumlG5iIgMVvaifOrvSW7G6knvQM++0tEfMBQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/1ds-core-js": "4.3.9",
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+                "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+            }
+        },
+        "node_modules/@microsoft/applicationinsights-channel-js": {
+            "version": "3.3.9",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.3.9.tgz",
+            "integrity": "sha512-/yEgSe6vT2ycQJkXu6VF04TB5XBurk46ECV7uo6KkNhWyDEctAk1VDWB7EqXYdwLhKMbNOYX1pvz7fj43fGNqg==",
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/applicationinsights-common": "3.3.9",
+                "@microsoft/applicationinsights-core-js": "3.3.9",
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+                "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+            },
+            "peerDependencies": {
+                "tslib": ">= 1.0.0"
+            }
+        },
+        "node_modules/@microsoft/applicationinsights-common": {
+            "version": "3.3.9",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.3.9.tgz",
+            "integrity": "sha512-IgruOuDBxmBK9jYo7SqLJG7Z9OwmAmlvHET49srpN6pqQlEjRpjD1nfA3Ps4RSEbF89a/ad2phQaBp8jvm122g==",
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/applicationinsights-core-js": "3.3.9",
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+            },
+            "peerDependencies": {
+                "tslib": ">= 1.0.0"
+            }
+        },
+        "node_modules/@microsoft/applicationinsights-core-js": {
+            "version": "3.3.9",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.3.9.tgz",
+            "integrity": "sha512-xliiE9H09xCycndlua4QjajN8q5k/ET6VCv+e0Jjodxr9+cmoOP/6QY9dun9ptokuwR8TK0qOaIJ8z4fgslVSA==",
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+                "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+            },
+            "peerDependencies": {
+                "tslib": ">= 1.0.0"
+            }
+        },
+        "node_modules/@microsoft/applicationinsights-shims": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
+            "integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
+            "license": "MIT",
+            "dependencies": {
+                "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+            }
+        },
+        "node_modules/@microsoft/applicationinsights-web-basic": {
+            "version": "3.3.9",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.3.9.tgz",
+            "integrity": "sha512-8tLaAgsCpWjoaxit546RqeuECnHQPBLnOZhzTYG76oPG1ku7dNXaRNieuZLbO+XmAtg/oxntKLAVoPND8NRgcA==",
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/applicationinsights-channel-js": "3.3.9",
+                "@microsoft/applicationinsights-common": "3.3.9",
+                "@microsoft/applicationinsights-core-js": "3.3.9",
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+                "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+            },
+            "peerDependencies": {
+                "tslib": ">= 1.0.0"
+            }
+        },
+        "node_modules/@microsoft/dynamicproto-js": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.3.tgz",
+            "integrity": "sha512-JTWTU80rMy3mdxOjjpaiDQsTLZ6YSGGqsjURsY6AUQtIj0udlF/jYmhdLZu8693ZIC0T1IwYnFa0+QeiMnziBA==",
+            "license": "MIT",
+            "dependencies": {
+                "@nevware21/ts-utils": ">= 0.10.4 < 2.x"
+            }
+        },
         "node_modules/@microsoft/vscode-azext-azureauth": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureauth/-/vscode-azext-azureauth-4.2.0.tgz",
@@ -1129,6 +1238,21 @@
                 "@azure/core-rest-pipeline": "^1.16.0",
                 "@azure/ms-rest-azure-env": "^2.0.0"
             }
+        },
+        "node_modules/@nevware21/ts-async": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.5.4.tgz",
+            "integrity": "sha512-IBTyj29GwGlxfzXw2NPnzty+w0Adx61Eze1/lknH/XIVdxtF9UnOpk76tnrHXWa6j84a1RR9hsOcHQPFv9qJjA==",
+            "license": "MIT",
+            "dependencies": {
+                "@nevware21/ts-utils": ">= 0.11.6 < 2.x"
+            }
+        },
+        "node_modules/@nevware21/ts-utils": {
+            "version": "0.12.5",
+            "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.12.5.tgz",
+            "integrity": "sha512-JPQZWPKQJjj7kAftdEZL0XDFfbMgXCGiUAZe0d7EhLC3QlXTlZdSckGqqRIQ2QNl0VTEZyZUvRBw6Ednw089Fw==",
+            "license": "MIT"
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -2038,6 +2162,20 @@
             },
             "engines": {
                 "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@vscode/extension-telemetry": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-1.0.0.tgz",
+            "integrity": "sha512-vaTZE65zigWwSWYB6yaZUAyVC/Ux+6U82hnzy/ejuS/KpFifO+0oORNd5yAoPeIRnYjvllM6ES3YlX4K5tUuww==",
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/1ds-core-js": "^4.3.4",
+                "@microsoft/1ds-post-js": "^4.3.4",
+                "@microsoft/applicationinsights-web-basic": "^3.3.4"
+            },
+            "engines": {
+                "vscode": "^1.75.0"
             }
         },
         "node_modules/@vscode/test-electron": {
@@ -10212,15 +10350,6 @@
             },
             "engines": {
                 "node": ">=10.13.0"
-            }
-        },
-        "node_modules/vscode-extension-telemetry": {
-            "version": "0.4.5",
-            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.4.5.tgz",
-            "integrity": "sha512-YhPiPcelqM5xyYWmD46jIcsxLYWkPZhAxlBkzqmpa218fMtTT17ERdOZVCXcs1S5AjvDHlq43yCgi8TaVQjjEg==",
-            "deprecated": "This package has been renamed to @vscode/extension-telemetry, please update to the new name",
-            "engines": {
-                "vscode": "^1.60.0"
             }
         },
         "node_modules/vscode-uri": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "gke",
         "aws"
     ],
-    "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
+    "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "icon": "images/k8s-logo.png",
     "activationEvents": [
         "onLanguage:helm",
@@ -1287,7 +1287,7 @@
         "tar": "^7.4.3",
         "tmp": "^0.2.5",
         "unzipper": "^0.10.14",
-        "vscode-extension-telemetry": "^0.4.5",
+        "@vscode/extension-telemetry": "^1.0.0",
         "vscode-uri": "^3.1.0",
         "yaml-ast-parser": "^0.0.43",
         "yamljs": "^0.3.0"

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,15 +1,16 @@
-import TelemetryReporter from 'vscode-extension-telemetry';
+import { TelemetryReporter } from '@vscode/extension-telemetry';
 import vscode = require('vscode');
 
-export let reporter: TelemetryReporter | undefined;
+export let reporter: TelemetryReporter;
 
 export class Reporter extends vscode.Disposable {
 
     constructor(ctx: vscode.ExtensionContext) {
         super(() => { if (reporter) { reporter.dispose(); } });
         const packageInfo = getPackageInfo(ctx);
-        reporter = packageInfo && new TelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey);
-
+        if (packageInfo) {
+            reporter = new TelemetryReporter(packageInfo.aiKey);
+        }
     }
 }
 


### PR DESCRIPTION
We are currently relying on a [deprecated telemetry library](https://www.npmjs.com/package/vscode-extension-telemetry). This is now fails on the FOSSA licensing and this upgrade will also help in upgrading any other associated packages..

These changes move us onto the latest library.

More details of similar approach reside here which we have done in past: https://github.com/Azure/vscode-aks-tools/pull/379 - hence the inspiration and fix. 

Thank you, cc: @tejhan, @gambtho,  and @squillace 


Key fix here is this one: 

<img width="568" height="57" alt="Screenshot 2025-08-29 at 8 43 55 AM" src="https://github.com/user-attachments/assets/9b1f87a3-6a8b-4c04-b394-9d810d0ea2a3" />
