### PR TITLE
Fix security vulnerability by escaping shell arguments.

### DIFF
--- a/src/shell.ts
+++ b/src/shell.ts
@@ -8,6 +8,7 @@ import { host } from './host';
 import { ChildProcess } from 'child_process';
 import { getKubeconfigPath } from './components/kubectl/kubeconfig';
 import { ExecResult } from './binutilplusplus';
+import { escapeShellArg } from './utils/shell-escape';
 
 export enum Platform {
     Windows,
@@ -212,7 +213,7 @@ function pathEntrySeparator() {
 
 function which(bin: string): string | null {
     if (getUseWsl()) {
-        const result = shelljs.exec(`wsl.exe which ${bin}`);
+        const result = shelljs.exec(`wsl.exe which ${escapeShellArg(bin)}`);
         if (result.code !== 0) {
             throw new Error(result.stderr);
         }
@@ -224,7 +225,7 @@ function which(bin: string): string | null {
 function cat(path: string): string {
     if (getUseWsl()) {
         const filePath = path.replace(/\\/g, '/');
-        const result = shelljs.exec(`wsl.exe cat ${filePath}`);
+        const result = shelljs.exec(`wsl.exe cat ${escapeShellArg(filePath)}`);
         if (result.code !== 0) {
             throw new Error(result.stderr);
         }
@@ -236,7 +237,7 @@ function cat(path: string): string {
 function ls(path: string): string[] {
     if (getUseWsl()) {
         const filePath = path.replace(/\\/g, '/');
-        const result = shelljs.exec(`wsl.exe ls ${filePath}`);
+        const result = shelljs.exec(`wsl.exe ls ${escapeShellArg(filePath)}`);
         if (result.code !== 0) {
             throw new Error(result.stderr);
         }

--- a/src/utils/shell-escape.ts
+++ b/src/utils/shell-escape.ts
@@ -1,0 +1,13 @@
+/**
+ * Utility functions for safely escaping shell arguments
+ */
+
+/**
+ * Safely escape a shell argument to prevent command injection
+ * @param arg The argument to escape
+ * @returns The escaped argument safe for shell execution
+ */
+export function escapeShellArg(arg: string): string {
+    // Escape single quotes by ending the quoted string, adding an escaped quote, and starting a new quoted string
+    return `'${arg.replace(/'/g, "'\"'\"'")}'`;
+}

--- a/src/wsl-fs.ts
+++ b/src/wsl-fs.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as shell from 'shelljs';
 
 import { getUseWsl } from './components/config/config';
+import { escapeShellArg } from './utils/shell-escape';
 
 export interface Stats {
     isDirectory(): boolean;
@@ -21,7 +22,7 @@ class StatImpl {
 export function statSync(file: string): Stats {
     if (getUseWsl()) {
         const filePath = file.replace(/\\/g, '/');
-        const result = shell.exec(`wsl.exe sh -c "ls -l ${filePath} | grep -v total"`);
+        const result = shell.exec(`wsl.exe sh -c "ls -l ${escapeShellArg(filePath)} | grep -v total"`);
         if (result.code !== 0) {
             if (result.stderr.indexOf('No such file or directory') !== -1) {
                 return new StatImpl('');
@@ -37,7 +38,7 @@ export function statSync(file: string): Stats {
 export function existsSync(file: string): boolean {
     if (getUseWsl()) {
         const filePath = file.replace(/\\/g, '/');
-        const result = shell.exec(`wsl.exe ls ${filePath}`);
+        const result = shell.exec(`wsl.exe ls ${escapeShellArg(filePath)}`);
         return result.code === 0;
     } else {
         return fs.existsSync(file);
@@ -47,7 +48,7 @@ export function existsSync(file: string): boolean {
 export function unlinkSync(file: string) {
     if (getUseWsl()) {
         const filePath = file.replace(/\\/g, '/');
-        const result = shell.exec(`wsl.exe rm -rf ${filePath}`);
+        const result = shell.exec(`wsl.exe rm -rf ${escapeShellArg(filePath)}`);
         if (result.code !== 0) {
             throw new Error(result.stderr);
         }


### PR DESCRIPTION
This PR is there to fix few leftover medium security scan alerts.

1. Created a new shared utility module `shell-escape.ts` that contains the `escapeShellArg` function with proper documentation.
2. Updated `shell.ts`:
    * Added import for the shared `escapeShellArg` function
    * Removed the local duplicate function
    * All existing usage remains the same
3. Updated `wsl-fs.ts`:
    * Added import for the shared `escapeShellArg` function
    * Removed the local duplicate function
    * All existing usage remains the same

I have moved a common shared escape function into new module, I am totally fine in duplicating into separate fils as well, only one re4ason I convinced to make this function shared via new file is because of thinking in the lines of DRY Principle and for consistency as both files now use the exact same escaping logic.

Thanks heaps, gentle fyi @tejhan, @ReinierCC, @bosesuneha , @davidgamero & @qpetraroia ❤️ ❤️ cc: @squillace , @gambtho

![](https://media.giphy.com/media/v1.Y2lkPWVjZjA1ZTQ3YWtvdjM1Yml0d213Nzl5OGc4dXIzZG96Z2p6bnI2M3lwczhlenRxdCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/1C8bHHJturSx2/giphy.gif)