### PR TITLE
Fix typo in error message for Helm binary check

### DIFF
--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -791,7 +791,7 @@ export function ensureHelm(mode: EnsureMode) {
     if (sh.which("helm")) {
         return true;
     } 
-    return handleHelmNotFoundError(mode, 'Could not find Helm binay.')
+    return handleHelmNotFoundError(mode, 'Could not find Helm binary.')
 }
 
 // Displays error message with option to install dependencies or disable Helm checks.


### PR DESCRIPTION
Just a tiny fix of what I believe is a typo in an error message I just encountered when using the VS Code plugin.