### PR TITLE
Adding filtering for accessible namespaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,11 @@
                             "type": "string",
                             "description": "The namespace to use for all commands"
                         },
+                        "vs-kubernetes.hideInaccessibleNamespaces": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Hide namespaces that you don't have permissions to access. Useful in multi-tenant clusters."
+                        },
                         "vs-kubernetes.kubectl-path": {
                             "type": "string",
                             "description": "[deprecated - use top level property] File path to a kubectl binary."
@@ -240,6 +245,7 @@
                     },
                     "default": {
                         "vs-kubernetes.namespace": "",
+                        "vs-kubernetes.hideInaccessibleNamespaces": false,
                         "vs-kubernetes.kubectl-path": "",
                         "vs-kubernetes.helm-path": "",
                         "vs-kubernetes.minikube-path": "",
@@ -502,6 +508,11 @@
                     "command": "extension.vsKubernetesDashboard",
                     "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.\\w*cluster($|\\s)/i",
                     "group": "0@3"
+                },
+                {
+                    "command": "extension.vsKubernetesShowAccessibleNamespaces",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.\\w*cluster($|\\s)/i",
+                    "group": "0@4"
                 },
                 {
                     "command": "extension.vsMinikubeStop",
@@ -970,6 +981,11 @@
             {
                 "command": "extension.vsKubernetesUseNamespace",
                 "title": "Use Namespace",
+                "category": "Kubernetes"
+            },
+            {
+                "command": "extension.vsKubernetesShowAccessibleNamespaces",
+                "title": "Filter Accessible Namespaces",
                 "category": "Kubernetes"
             },
             {

--- a/src/components/clusterexplorer/filter-accessible-namespaces.ts
+++ b/src/components/clusterexplorer/filter-accessible-namespaces.ts
@@ -1,0 +1,37 @@
+import { Kubectl } from "../../kubectl";
+import { ExecResult } from "../../binutilplusplus";
+
+/**
+ * Filters a list of namespaces to only those the user has access to.
+ * A namespace is considered accessible if the user can list any of these resources.
+ */
+
+export async function filterAccessibleNamespaces(
+    kubectl: Kubectl,
+    namespaces: string[]
+): Promise<string[]> {
+    // Resources to check - assume access to any of these means the namespace is accessible
+    const resourcesToCheck = ["pods", "deployments", "services"];
+
+    const accessChecks = namespaces.map(async (ns) => {
+        const checks = resourcesToCheck.map(async (resource) => {
+            const result = await kubectl.invokeCommand(
+                `auth can-i list ${resource} --namespace=${ns}`
+            );
+            return (
+                ExecResult.succeeded(result) && result.stdout.trim() === "yes"
+            );
+        });
+
+        const results = await Promise.all(checks);
+        const hasAnyAccess = results.some((hasAccess) => hasAccess);
+
+        return {
+            namespace: ns,
+            accessible: hasAnyAccess,
+        };
+    });
+
+    const results = await Promise.all(accessChecks);
+    return results.filter((r) => r.accessible).map((r) => r.namespace);
+}

--- a/src/components/clusterexplorer/resourcekinds/resourcekind.namespace.ts
+++ b/src/components/clusterexplorer/resourcekinds/resourcekind.namespace.ts
@@ -5,6 +5,7 @@ import { ResourceKind } from '../../../kuberesources';
 import { Kubectl } from '../../../kubectl';
 import * as kubectlUtils from '../../../kubectlUtils';
 import { ClusterExplorerNode } from '../node';
+import { filterAccessibleNamespaces } from '../filter-accessible-namespaces';
 
 export const namespaceUICustomiser = {
     customiseTreeItem(resource: ResourceNode, treeItem: vscode.TreeItem): void {
@@ -21,6 +22,22 @@ export const namespaceUICustomiser = {
 export const namespaceLister = {
     async list(kubectl: Kubectl, kind: ResourceKind): Promise<ClusterExplorerNode[]> {
         const namespaces = await kubectlUtils.getNamespaces(kubectl);
-        return namespaces.map((ns) => ResourceNode.create(kind, ns.name, ns.metadata, { namespaceInfo: ns }));
+        
+        const config = vscode.workspace.getConfiguration('vs-kubernetes');
+        const hideInaccessible = config['vs-kubernetes.hideInaccessibleNamespaces'] || false;
+        
+        if (!hideInaccessible) {
+            // default behavior
+            return namespaces.map((ns) => ResourceNode.create(kind, ns.name, ns.metadata, { namespaceInfo: ns }));
+        }
+        
+        // filter to only accessible namespaces
+        const namespaceNames = namespaces.map(ns => ns.name);
+        const accessibleNames = await filterAccessibleNamespaces(kubectl, namespaceNames);
+        const accessibleSet = new Set(accessibleNames);
+        
+        return namespaces
+            .filter(ns => accessibleSet.has(ns.name))
+            .map((ns) => ResourceNode.create(kind, ns.name, ns.metadata, { namespaceInfo: ns }));
     }
 };

--- a/src/components/kubectl/namespace.ts
+++ b/src/components/kubectl/namespace.ts
@@ -1,3 +1,4 @@
+import * as vscode from 'vscode';
 import { refreshExplorer } from '../clusterprovider/common/explorer';
 import { promptKindName } from '../../extension';
 import { host } from '../../host';
@@ -7,6 +8,7 @@ import { Kubectl } from '../../kubectl';
 import { ClusterExplorerNode } from '../clusterexplorer/node';
 import { NODE_TYPES } from '../clusterexplorer/explorer';
 import * as config from '../config/config';
+import { KubernetesExplorer } from '../clusterexplorer/explorer';
 
 
 export async function useNamespaceKubernetes(kubectl: Kubectl, explorerNode: ClusterExplorerNode) {
@@ -54,4 +56,21 @@ async function switchToNamespace(kubectl: Kubectl, currentNS: string, resource: 
             host.showInformationMessage(`Switched to namespace ${toSwitchNamespace}`);
         }
     }
+}
+
+export async function showAccessibleNamespacesOnly(_kubectl: Kubectl, treeProvider: KubernetesExplorer, _explorerNode: ClusterExplorerNode) {
+    // get cluster 
+    const vsKubernetesConfig = vscode.workspace.getConfiguration('vs-kubernetes');
+    const currentValue = vsKubernetesConfig['vs-kubernetes.hideInaccessibleNamespaces'] || false;
+    
+    await config.setConfigValue('vs-kubernetes.hideInaccessibleNamespaces', !currentValue);
+    
+    if (!currentValue) {
+        host.showInformationMessage('Namespace filtering enabled. Refreshing tree view...');
+    } else {
+        host.showInformationMessage('Namespace filtering disabled. Showing all namespaces...');
+    }
+    
+    // refresh to apply change
+    treeProvider.refresh();
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,7 @@ import * as explainer from './explainer';
 import { shell } from './shell';
 import * as configmaps from './configMap';
 import * as kuberesources from './kuberesources';
-import { useNamespaceKubernetes } from './components/kubectl/namespace';
+import { useNamespaceKubernetes, showAccessibleNamespacesOnly } from './components/kubectl/namespace';
 import { EventDisplayMode, getEvents } from './components/kubectl/events';
 import * as docker from './docker';
 import { kubeChannel } from './kubeChannel';
@@ -214,6 +214,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
         registerCommand('extension.vsKubernetesClusterInfo', clusterInfoKubernetes),
         registerCommand('extension.vsKubernetesDeleteContext', deleteContextKubernetes),
         registerCommand('extension.vsKubernetesUseNamespace', (explorerNode: ClusterExplorerNode) => { useNamespaceKubernetes(kubectl, explorerNode); } ),
+        registerCommand('extension.vsKubernetesShowAccessibleNamespaces', (explorerNode: ClusterExplorerNode) => { showAccessibleNamespacesOnly(kubectl, treeProvider, explorerNode); }),
         registerCommand('extension.vsKubernetesDashboard', () => { dashboardKubernetes(kubectl); }),
         registerCommand('extension.vsKubernetesAddWatch', (explorerNode: ClusterExplorerNode) => { addWatch(treeProvider, explorerNode); }),
         registerCommand('extension.vsKubernetesDeleteWatch', (explorerNode: ClusterExplorerNode) => { deleteWatch(treeProvider, explorerNode); }),


### PR DESCRIPTION
This PR adds the ability to filter out namespaces for accessibility. For users with multi-tenant clusters, there may be a significant amount of namespaces that they have limited access to, so being able to filter these down can be a good QOL improvement. 

This could probably be followed by additional features on the tree view, as it does seem a few users have reported potential feature inclusions and updates for the tree. (Pinning nodes, filtering resources etc.)

Keeping as a draft for now to allow for some discussion of whether this will be merged / improvement / upgrade ideas.

fyi @Tatsinnit 