### PR TITLE
Explicitly setting font-family for log viewer webview

### DIFF
--- a/src/components/logs/app/index.html
+++ b/src/components/logs/app/index.html
@@ -70,7 +70,8 @@
             word-wrap: anywhere;
         }
         #content {
-            color: var(--vscode-foreground)
+            color: var(--vscode-foreground);
+            font-family: var(--vscode-font-family);
         }
         .gl {
             color: #b5cea8;


### PR DESCRIPTION
This PR sets the font-family in the logs webview to `--vscode-font-family`.

The log viewer webview didn't set a font-family for the log content, causing it to fall back to the browser's default monospace font on some machines. On some systems with misconfigured fonts, this resulted in serif fonts being displayed instead. This fix ensures consistent font rendering across all platforms & should help with visibility issues some have reported.

Fixes issue
- https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1120