### PR TITLE
Adding helm v4 support for repo chart search

### DIFF
--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -80,6 +80,7 @@ export enum HelmSyntaxVersion {
     Unknown = 1,
     V2 = 2,
     V3 = 3,
+    V4 = 4,
 }
 
 let cachedVersion: HelmSyntaxVersion | undefined = undefined;
@@ -96,8 +97,14 @@ export async function helmSyntaxVersion(): Promise<HelmSyntaxVersion> {
             cachedVersion = HelmSyntaxVersion.V2;
         } else {
             const srHelm3 = await helmExecAsync(`version --short`);
-            if (srHelm3 && srHelm3.code === 0 && srHelm3.stdout.indexOf('v3') >= 0) {
-                cachedVersion = HelmSyntaxVersion.V3;
+            if (srHelm3 && srHelm3.code === 0) {
+                if (srHelm3.stdout.indexOf('v4') >= 0) {
+                    cachedVersion = HelmSyntaxVersion.V4;
+                } else if (srHelm3.stdout.indexOf('v3') >= 0) {
+                    cachedVersion = HelmSyntaxVersion.V3;
+                } else {
+                    return HelmSyntaxVersion.Unknown;
+                }
             } else {
                 return HelmSyntaxVersion.Unknown;
             }


### PR DESCRIPTION
This PR fixes an issue with viewing repo contents for users on Helm version 4. 

Helm v4 was released earlier this month with several breaking changes- one being the removed support of the `-l` flag for repo search. 

This PR adds logic to check for v4 & corresponding logic to use the correct flags for each version we check for (v2 - v4). Version 4 will now use the `--versions` flag isntead. 

This should resolve the following issue:

- https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1707