### PR TITLE
Adding User Feedback and Quick-Actions for Helm Chart Creation

### DIFF
--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -182,8 +182,34 @@ function helmDepUpCore(path: string) {
 export async function helmCreate(): Promise<void> {
     const createResult = await helmCreateCore("Chart name", "mychart");
 
-    if (createResult && failed(createResult)) {
+    if (!createResult) {
+        return;
+    }
+
+    if (failed(createResult)) {
         vscode.window.showErrorMessage(createResult.error[0]);
+        return;
+    }
+
+    // Show success message and reveal the created chart
+    const chartPath = createResult.result.path;
+    const chartName = createResult.result.name;
+    
+    logger.log(`⎈⎈⎈ Created chart ${chartName} at ${chartPath}`);
+    
+    const action = await vscode.window.showInformationMessage(
+        `Created Helm chart '${chartName}'`,
+        'Open Chart.yaml',
+        'Open Folder'
+    );
+
+    if (action === 'Open Chart.yaml') {
+        const chartYamlPath = filepath.join(chartPath, 'Chart.yaml');
+        const doc = await vscode.workspace.openTextDocument(chartYamlPath);
+        await vscode.window.showTextDocument(doc);
+    } else if (action === 'Open Folder') {
+        const chartUri = vscode.Uri.file(chartPath);
+        await vscode.commands.executeCommand('revealInExplorer', chartUri);
     }
 }
 


### PR DESCRIPTION
Observed that our Helm chart creation flow currently provides no user feedback- charts are generated silently with no indication of success- only failure, which isn’t ideal from a UX standpoint.

I’ve added notifications for both successful and failed chart creation, along with quick-action options to open the generated Chart.yaml or the containing folder.

These improvements give users immediate feedback on the result of the operation and offer convenient entry points to the created files, which should help improve general QOL & usability of the feature.

https://github.com/user-attachments/assets/c150579e-9fa1-48d9-a63d-4602db8220e9

