### PR TITLE
Fix Helm v4 version command 

### DIFF
--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -63,7 +63,7 @@ function helmReleaseFromJSON(json: any): HelmRelease {
 
 export async function helmVersion() {
     const syntaxVersion = await helmSyntaxVersion();
-    const versionArgs = (syntaxVersion === HelmSyntaxVersion.V3) ? '' : '-c';
+    const versionArgs = (syntaxVersion === HelmSyntaxVersion.V3 || syntaxVersion === HelmSyntaxVersion.V4) ? '' : '-c';
     const sr = await helmExecAsync(`version ${versionArgs}`);
     if (!sr) {
         vscode.window.showErrorMessage('Failed to run Helm');


### PR DESCRIPTION
This PR fixes the `Helm: Version` command for helm v4 users. 

Our logic previously only considered v2 & v3, so we have conditionals that treat `!v3` the same as `v2`. Thus, the `-c` shorthand was incorrectly applied for `helm version`, which would make running `Helm: Version` on v4 result in the error: `Error: unknown shorthand flag: 'c' in -c`

This fixes that logic to account for v4. 

This will be followed by fixes to ensure our logic is fully aware of current versions and v2 specific logic isn't defaulted anymore.