### PR TITLE
Enabling Helm: Inspect Chart on .tgz files

### DIFF
--- a/package.json
+++ b/package.json
@@ -438,6 +438,11 @@
                     "when": "resourceLangId == yaml",
                     "command": "extension.helmConvertToTemplate",
                     "group": "2_helm@98"
+                },
+                {
+                    "when": "resourceExtname == .tgz",
+                    "command": "extension.helmInspectChart",
+                    "group": "2_helm@1"
                 }
             ],
             "view/title": [

--- a/src/helm.documentProvider.ts
+++ b/src/helm.documentProvider.ts
@@ -63,6 +63,7 @@ export class HelmInspectDocumentProvider implements vscode.TextDocumentContentPr
                     return;
                 }
                 console.log(`Inspect failed: ${out} ${err}`);
+                vscode.window.showErrorMessage(`Helm inspect failed: ${err || out}`);
                 reject(err);
             };
 


### PR DESCRIPTION
This PR allows the `Inspect Chart` command to be ran on `.tgz` files. 

Our documentation lists this as existing functionality, although it appears that the hook for the actual command into the context menu might have been removed/overlooked at some point.

This PR adds that option so users can inspect local charts. Additionally, I've added a vscode error message for failed chart inspects.

Fixes issue: 
- https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1426