### PR TITLE
Docs: Adding missing commands & clarifying invocation contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,19 +105,25 @@ If you want to skip TLS verification for a particular cluster, you can edit your
    * `Kubernetes: Load` - Load a resource from the Kubernetes API and create a new editor window.
    * `Kubernetes: Get` - Get the status for a specific resource.
    * `Kubernetes: Logs` - Open a view with a set of options to display/follow logs.
+   * `Kubernetes: Describe` - Describe the object in a terminal window.
+   * `Kubernetes: Delete` - Delete a Kubernetes resource.
+   * `Kubernetes: Delete Now` - Force delete a pod immediately without waiting for graceful termination.
    * `Kubernetes: Follow Events` - Follow events on a selected namespace.
    * `Kubernetes: Show Events` - Show events on a selected namespace.
-   * `Kubernetes: Watch` - Watch a specific resource or all resources of that object type, and update the cluster explorer as they change
-   * `Kubernetes: Stop Watching` - Stop watching the specific resource
+
+   These commands are designed for use from the cluster explorer tree view:
+
+   * `Kubernetes: Watch` - Watch a specific resource and update the cluster explorer as it changes.
+   * `Kubernetes: Stop Watching` - Stop watching the specific resource.
+   * `Kubernetes: Copy Name` - Copy the name of a resource to the clipboard.
+   * `Kubernetes: Run CronJob Now` - Manually trigger a CronJob to run immediately.
 
 #### Commands while viewing a Kubernetes manifest file
 
    * `Kubernetes: Explain` - Use the `kubectl explain ...` tool to annotate Kubernetes API objects
    * `Kubernetes: Create` - Create an object using the current document
-   * `Kubernetes: Delete` - Delete an object contained in the current document.
    * `Kubernetes: Apply` - Apply changes to an object contained in the current document.
    * `Kubernetes: Expose` - Expose the object in the current document as a service.
-   * `Kubernetes: Describe` - Describe the object in a terminal window.
    * `Kubernetes: Diff` - Show the difference between a local copy of the object, and that which is deployed to the cluster.
 
 #### Commands for application directories
@@ -181,6 +187,9 @@ Minikube tools to be installed and available on your PATH.
      * `Helm: Insert Dependency` - Insert a dependency YAML fragment
      * `Helm: Dependency Update` - Update a chart's dependencies
      * `Helm: Package` - Package a chart directory into a chart archive
+     * `Helm: Fetch` - Download a chart from a repository (can be run via the palette or by right-clicking a Helm repo)
+     * `Helm: Install` - Install a chart to the cluster
+     * `Helm: Show Dependencies` - Show the dependencies for a chart
      * `Helm: Convert to Template` - Create a template based on an existing resource or manifest
      * `Helm: Convert to Template Parameter` - Convert a fixed value in a template to a parameter in the `values.yaml` file
    * Code lenses for:
@@ -208,8 +217,10 @@ Minikube tools to be installed and available on your PATH.
        * `vs-kubernetes.suppress-kubectl-not-found-alerts` - Turns off the warning (and installation prompt) if `kubectl` was not found. You should not normally set this, as most of the extension depends on `kubectl`, but it can be useful if working primarily with Helm.
        * `vs-kubernetes.suppress-helm-not-found-alerts` - Turns off the warning (and installation prompt) if `helm` was not found.
        * `vs-kubernetes.ignore-recommendations` - Set to true to silence Kubernetes extension recommendation notifications.
+       * `vs-kubernetes.crd-code-completion` - Set to "enabled" or "disabled" to control smart code completion for CRDs.
        * `vs-kubernetes.minikube-show-information-expiration` - Set to valid expiration date for minikube install to show information dialog box to display.
        * `vs-kubernetes.enable-minimal-workflow` - Enables the minimal workflow for several actions (Get, Describe, Scale, Expose, Switch). By executing one of those commands the queries to the cluster are reduced at minimum and users are able to freely type the resource name to use.
+       * `resource-commands-on-files` - If true, show Kubernetes resource commands (Create, Apply, Delete) on file context menu for all YAML files.
    * `vsdocker.imageUser` - Image prefix for the container images e.g. 'docker.io/brendanburns'
    * `checkForMinikubeUpgrade` - On extension startup, notify if a minikube upgrade is available. Defaults to true.
    * `disable-lint` - Disable all linting of Kubernetes files


### PR DESCRIPTION
This PR Improves the README documentation accuracy for several commands & settings.

## Changes
- Added missing commands: Delete Now, Copy Name, Run CronJob Now
- Added missing settings: crd-code-completion, resource-commands-on-files
- Added Helm commands: Fetch, Install, Show Dependencies
- Reorganized General commands section to clarify which commands are designed for the cluster explorer tree view