### PR TITLE
Adding user feedback for watch/unwatch commands

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -814,13 +814,31 @@ async function getKubernetes(explorerNode?: any) {
 function addWatch(tree: explorer.KubernetesExplorer, explorerNode?: ClusterExplorerNode) {
     if (explorerNode) {
         tree.watch(explorerNode);
+        const displayName = getWatchDisplayName(explorerNode);
+        if (displayName) {
+            vscode.window.showInformationMessage(`Watching ${displayName}`);
+        }
     }
 }
 
 function deleteWatch(tree: explorer.KubernetesExplorer, explorerNode?: ClusterExplorerNode) {
     if (explorerNode) {
         tree.stopWatching(explorerNode);
+        const displayName = getWatchDisplayName(explorerNode);
+        if (displayName) {
+            vscode.window.showInformationMessage(`Stopped watching ${displayName}`);
+        }
     }
+}
+
+// Get a properly pluralized name for the watched resource
+function getWatchDisplayName(node: ClusterExplorerNode): string | undefined {
+    if (node.nodeType === 'folder.resource') {
+        return node.kind.pluralDisplayName;
+    } else if (node.nodeType === 'resource') {
+        return node.kindName;
+    }
+    return undefined;
 }
 
 function findVersion() {


### PR DESCRIPTION
This PR adds information messages when users explicitly watch or stop watching resources.

- Show "Watching/Stop watching {resource}" message when watch commands are invoked
- Use plural display names for folders (eg. `Watching Pods`)
- Use kind/name format for individual resources (e.g. `Watching pod/nginx`)