### PR TITLE
Publish release 1.3.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [1.3.29]
+
+* Dependabot PRs
+* Fix: Handling multi-path KUBECONFIG and updating kubectl download URLs (#1755)
+* Remove spawn-rx dependency and replace with native Node.js implementation (#1770)
+* Highlight matching end tags (#1762)
+* Update vscode engine and package. (#1763)
+* Adding user feedback for watch/unwatch commands (#1756)
+* Add dependabot update for GH Actions. (#1742)
+
+Contributors: Happy New Year folks!! Contributions and Reviews from fanny-jiang, tejhan, ashu8912. Thank you all!!
 
 ## [1.3.28]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-kubernetes-tools",
-    "version": "1.3.28",
+    "version": "1.3.29",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-kubernetes-tools",
-            "version": "1.3.28",
+            "version": "1.3.29",
             "license": "Apache-2.0",
             "dependencies": {
                 "@azure/arm-containerservice": "^24.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-kubernetes-tools",
     "displayName": "Kubernetes",
     "description": "Develop, deploy and debug Kubernetes applications",
-    "version": "1.3.28",
+    "version": "1.3.29",
     "publisher": "ms-kubernetes-tools",
     "engines": {
         "vscode": "^1.107.0"


### PR DESCRIPTION
Hiya All, this PR is for release `1.3.29` with some nice fixes from @fanny-jiang and @tejhan , thank you @ashu8912  for helping out in testing as well. 

This Prelease contains following updates:

* Dependabot PRs
* Fix: Handling multi-path KUBECONFIG and updating kubectl download URLs (#1755)
* Remove spawn-rx dependency and replace with native Node.js implementation (#1770)
* Highlight matching end tags (#1762)
* Update vscode engine and package. (#1763)
* Adding user feedback for watch/unwatch commands (#1756)
* Add dependabot update for GH Actions. (#1742)

❤️  Contributors: Happy new years folks!! Contributions and Reviews from fanny-jiang, tejhan, ashu8912. Thank you all!!

Gentle fyi to @tejhan , @fanny-jiang , @ashu8912 , @bosesuneha , @davidgamero , @ReinierCC , cc: @squillace , @gambtho

VSIX test: [vscode-kubernetes-tools-1.3.29-test.vsix.zip](https://github.com/user-attachments/files/24508928/vscode-kubernetes-tools-1.3.29-test.vsix.zip)

