### PR TITLE
quick fix to add support for extenstion  ms-python.debugpy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Have an idea for improving the extension? We'd love to hear it. Please [open an 
 
 ### Security Vulnerabilities
 
-**⚠️ Plase do not report security vulnerabilities through public GitHub issues.**
+**⚠️ Please do not report security vulnerabilities through public GitHub issues.**
 
 If you discover a security vulnerability, please follow the responsible disclosure process outlined in our [SECURITY.md](SECURITY.md) file.
 

--- a/src/debug/debugpyDebugProvider.ts
+++ b/src/debug/debugpyDebugProvider.ts
@@ -1,0 +1,108 @@
+import * as path from "path";
+import * as vscode from "vscode";
+
+import { IDebugProvider, PortInfo, Cancellable } from "./debugProvider";
+import { suggestedShellForContainer } from '../utils/container-shell';
+import * as config from '../components/config/config';
+import * as extensionUtils from "../extensionUtils";
+import { Kubectl } from "../kubectl";
+import { kubeChannel } from "../kubeChannel";
+import { ProcessInfo } from "./debugUtils";
+import { ExecResult } from "../binutilplusplus";
+import * as extensionConfig from '../components/config/config';
+
+const debuggerType = 'debugpy';
+const defaultPythonDebuggerExtensionId = 'ms-python.debugpy';
+
+export class DebugpyDebugProvider implements IDebugProvider {
+    remoteRoot: string | undefined;
+    shell: string;
+
+    public getDebuggerType(): string {
+        return debuggerType;
+    }
+
+    public async isDebuggerInstalled(): Promise<boolean> {
+        if (vscode.extensions.getExtension(defaultPythonDebuggerExtensionId)) {
+            return true;
+        }
+        const answer = await vscode.window.showInformationMessage(`Python debugging requires the '${defaultPythonDebuggerExtensionId}' extension. Would you like to install it now?`, "Install Now");
+        if (answer === "Install Now") {
+            return await extensionUtils.installVscodeExtension(defaultPythonDebuggerExtensionId);
+        }
+        return false;
+    }
+
+    public async startDebugging(workspaceFolder: string, sessionName: string, port: number | undefined, _pod: string, _pidToDebug: number | undefined): Promise<boolean> {
+        const debugConfiguration: vscode.DebugConfiguration = {
+            type: "debugpy",
+            request: "attach",
+            name: sessionName,
+            hostName: "localhost",
+            port
+        };
+        debugConfiguration.justMyCode = extensionConfig.getDebugJustMyCode();
+        const currentFolder = (vscode.workspace.workspaceFolders || []).find((folder) => folder.name === path.basename(workspaceFolder));
+        if (currentFolder && this.remoteRoot) {
+            debugConfiguration['pathMappings'] = [{
+                localRoot: workspaceFolder,
+                remoteRoot: this.remoteRoot
+            }];
+        }
+        return await vscode.debug.startDebugging(currentFolder, debugConfiguration);
+    }
+
+    public isSupportedImage(baseImage: string): boolean {
+        if (!baseImage) {
+            return false;
+        }
+        return baseImage.indexOf("python") >= 0;
+    }
+
+    public async resolvePortsFromFile(): Promise<PortInfo | undefined> {
+        return undefined;
+    }
+
+    public async resolvePortsFromContainer(kubectl: Kubectl, pod: string, podNamespace: string, container: string): Promise<PortInfo | undefined> {
+        this.shell = await suggestedShellForContainer(kubectl, pod, podNamespace, container);
+        this.remoteRoot = await this.tryGetRemoteRoot(kubectl, pod, podNamespace, container);
+        const rawDebugPortInfo = config.getPythonDebugPort() || 5678;
+        return {
+            debugPort: Number(rawDebugPortInfo)
+        };
+    }
+
+    async tryGetRemoteRoot(kubectl: Kubectl, podName: string, podNamespace: string | undefined, containerName: string | undefined): Promise<string | undefined> {
+        if (config.getPythonAutoDetectRemoteRoot()) {
+            kubeChannel.showOutput("Trying to detect remote root.");
+            const nsarg = podNamespace ? `--namespace ${podNamespace}` : '';
+            const containerCommand = containerName? `-c ${containerName}` : '';
+            const execCmd = `exec ${podName} ${nsarg} ${containerCommand} -- ${this.shell} -c 'readlink /proc/1/cwd'`;
+            const execResult = await kubectl.invokeCommand(execCmd);
+            if (ExecResult.succeeded(execResult)) {
+                const remoteRoot = execResult.stdout.replace(/(\r\n|\n|\r)/gm, '');
+                kubeChannel.showOutput(`Got remote root from container: ${remoteRoot}`);
+                return remoteRoot;
+            }
+        }
+        if (config.getPythonRemoteRoot()) {
+            const remoteRoot = config.getPythonRemoteRoot();
+            kubeChannel.showOutput(`Setting remote root to ${remoteRoot}`);
+            return remoteRoot;
+        }
+
+        return undefined;
+    }
+
+    public filterSupportedProcesses(_processes: ProcessInfo[]): ProcessInfo[] | undefined {
+        return undefined;
+    }
+
+    public isPortRequired(): boolean {
+        return true;
+    }
+
+    public async getDebugArgs(): Promise<Cancellable> {
+        return { cancelled: false };
+    }
+}

--- a/src/debug/providerRegistry.ts
+++ b/src/debug/providerRegistry.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 
 import { IDebugProvider } from "./debugProvider";
+import { DebugpyDebugProvider } from "./debugpyDebugProvider";
 import { DotNetDebugProvider } from "./dotNetDebugProvider";
 import { GoDebugProvider } from "./goDebugProvider";
 import { JavaDebugProvider } from "./javaDebugProvider";
@@ -9,6 +10,7 @@ import { PythonDebugProvider } from "./pythonDebugProvider";
 import { ProcessInfo } from "./debugUtils";
 
 const supportedProviders: IDebugProvider[] = [
+    new DebugpyDebugProvider(),
     new DotNetDebugProvider(),
     new GoDebugProvider(),
     new JavaDebugProvider(),


### PR DESCRIPTION
Relasted to issue https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1817, The original debugger functionality built into the general Python extension (ms-python.python) has been deprecated and its functionality moved to a dedicated, separate extension named "Python Debugger" (ms-python.debugpy). 

This PR adds support to the Kubernetes Tools extension to support the new debugger.

The new src/debug/debugpyDebugProvider.ts is just a copy of src/debug/pythonDebugProvider.ts with minor changes.

```
--- src/debug/debugpyDebugProvider.ts   2026-02-13 08:14:05.680172097 -0500
+++ src/debug/pythonDebugProvider.ts    2026-02-09 17:22:43.241279684 -0500
@@ -11,10 +11,10 @@
 import { ExecResult } from "../binutilplusplus";
 import * as extensionConfig from '../components/config/config';
 
-const debuggerType = 'debugpy';
-const defaultPythonDebuggerExtensionId = 'ms-python.debugpy';
+const debuggerType = 'python';
+const defaultPythonDebuggerExtensionId = 'ms-python.python';
 
-export class DebugpyDebugProvider implements IDebugProvider {
+export class PythonDebugProvider implements IDebugProvider {
     remoteRoot: string | undefined;
     shell: string;
 
@@ -35,7 +35,7 @@
 
     public async startDebugging(workspaceFolder: string, sessionName: string, port: number | undefined, _pod: string, _pidToDebug: number | undefined): Promise<boolean> {
         const debugConfiguration: vscode.DebugConfiguration = {
-            type: "debugpy",
+            type: "python",
             request: "attach",
             name: sessionName,
             hostName: "localhost",
```

I have tested and validated these changes work on VSCode Version: 1.109.5 running on macOS/Darwin arm64 25.3.0.
