### PR TITLE
Add signed release mechanism

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,74 @@
+name: Release k8s VS Code Extension
+on: [workflow_dispatch]
+
+jobs:
+  release:
+    permissions:
+      contents: write
+      id-token: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6.0.1
+
+      - name: Setup Node
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build extension
+        run: npm run compile
+
+      # ------------------------
+      # Package VSIX
+      # ------------------------
+      - name: Package VSIX
+        run: npx vsce package
+
+      - name: Get VSIX filename
+        id: vsix
+        run: |
+          echo "VSIX_FILE=$(ls *.vsix)" >> $GITHUB_OUTPUT
+
+      # ------------------------
+      # Install Cosign
+      # ------------------------
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+
+      # ------------------------
+      # Sign VSIX (Keyless)
+      # ------------------------
+      - name: Sign VSIX
+        env:
+          COSIGN_EXPERIMENTAL: "1"
+        run: |
+          cosign sign-blob \
+            --yes \
+            --output-signature ${{ steps.vsix.outputs.VSIX_FILE }}.sig \
+            --output-certificate ${{ steps.vsix.outputs.VSIX_FILE }}.pem \
+            ${{ steps.vsix.outputs.VSIX_FILE }}
+
+      # ------------------------
+      # Create GitHub Release
+      # ------------------------
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        with:
+          files: |
+            ${{ steps.vsix.outputs.VSIX_FILE }}
+            ${{ steps.vsix.outputs.VSIX_FILE }}.sig
+            ${{ steps.vsix.outputs.VSIX_FILE }}.pem
+
+      # ------------------------
+      # Publish to Marketplace
+      # ------------------------
+      - name: Publish to VS Code Marketplace
+        uses: HaaLeo/publish-vscode-extension@f4ece70f329f66686bd71c54b1671353fe320e49 # v1.7.0
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          extensionFile: ${{ steps.vsix.outputs.VSIX_FILE }}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -54,17 +54,6 @@ jobs:
             ${{ steps.vsix.outputs.VSIX_FILE }}
 
       # ------------------------
-      # Create GitHub Release
-      # ------------------------
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
-        with:
-          files: |
-            ${{ steps.vsix.outputs.VSIX_FILE }}
-            ${{ steps.vsix.outputs.VSIX_FILE }}.sig
-            ${{ steps.vsix.outputs.VSIX_FILE }}.pem
-
-      # ------------------------
       # Publish to Marketplace
       # ------------------------
       - name: Publish to VS Code Marketplace
@@ -72,3 +61,17 @@ jobs:
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           extensionFile: ${{ steps.vsix.outputs.VSIX_FILE }}
+
+      # ------------------------
+      # Create GitHub Release
+      # ------------------------
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes \
+            ${{ steps.vsix.outputs.VSIX_FILE }} \
+            ${{ steps.vsix.outputs.VSIX_FILE }}.sig \
+            ${{ steps.vsix.outputs.VSIX_FILE }}.pem

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -25,6 +25,7 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
       - name: Build extension
         run: npm run compile
 
@@ -53,7 +54,9 @@ jobs:
 
       - name: Get VSIX filename
         id: vsix
-        run: echo "VSIX_FILE=$(ls *.vsix)" >> $GITHUB_OUTPUT
+        run: |
+          echo "VSIX_FILE=$(ls *.vsix)" >> $GITHUB_OUTPUT
+
 
       # ------------------------
       # Install Cosign
@@ -64,8 +67,6 @@ jobs:
       # Sign VSIX (OIDC Keyless)
       # ------------------------
       - name: Sign VSIX
-        env:
-          COSIGN_EXPERIMENTAL: "1"
         run: |
           cosign sign-blob \
             --yes \
@@ -79,6 +80,8 @@ jobs:
         run: |
           cosign verify-blob \
             --bundle ${{ steps.vsix.outputs.VSIX_FILE }}.bundle \
+            --certificate-identity-regexp "https://github.com/${{ github.repository }}/" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             ${{ steps.vsix.outputs.VSIX_FILE }}
 
       # ------------------------

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -9,9 +9,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # ------------------------
+      # Checkout
+      # ------------------------
       - name: Checkout
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6.0.1
 
+      # ------------------------
+      # Setup Node
+      # ------------------------
       - name: Setup Node
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
@@ -19,9 +25,25 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
       - name: Build extension
         run: npm run compile
+
+      # ------------------------
+      # Get Version From package.json
+      # ------------------------
+      - name: Get current package version
+        id: package_version
+        uses: martinbeentjes/npm-get-version-action@3cf273023a0dda27efcd3164bdfb51908dd46a5b # v1.3.1
+
+      # ------------------------
+      # Validate Changelog
+      # ------------------------
+      - name: Check version is mentioned in Changelog
+        uses: mindsers/changelog-reader-action@32aa5b4c155d76c94e4ec883a223c947b2f02656 # v2.2.3
+        id: changelog_reader
+        with:
+          version: ${{ steps.package_version.outputs.current-version }}
+          path: 'CHANGELOG.md'
 
       # ------------------------
       # Package VSIX
@@ -31,17 +53,15 @@ jobs:
 
       - name: Get VSIX filename
         id: vsix
-        run: |
-          echo "VSIX_FILE=$(ls *.vsix)" >> $GITHUB_OUTPUT
+        run: echo "VSIX_FILE=$(ls *.vsix)" >> $GITHUB_OUTPUT
 
       # ------------------------
       # Install Cosign
       # ------------------------
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+      - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
 
       # ------------------------
-      # Sign VSIX (Keyless)
+      # Sign VSIX (OIDC Keyless)
       # ------------------------
       - name: Sign VSIX
         env:
@@ -49,29 +69,47 @@ jobs:
         run: |
           cosign sign-blob \
             --yes \
-            --output-signature ${{ steps.vsix.outputs.VSIX_FILE }}.sig \
-            --output-certificate ${{ steps.vsix.outputs.VSIX_FILE }}.pem \
+            --bundle ${{ steps.vsix.outputs.VSIX_FILE }}.bundle \
             ${{ steps.vsix.outputs.VSIX_FILE }}
+
+      # ------------------------
+      # Verify Signature Before Release
+      # ------------------------
+      - name: Verify VSIX Signature
+        run: |
+          cosign verify-blob \
+            --bundle ${{ steps.vsix.outputs.VSIX_FILE }}.bundle \
+            ${{ steps.vsix.outputs.VSIX_FILE }}
+
+      # ------------------------
+      # Create GitHub Release (Version Tag)
+      # ------------------------
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.package_version.outputs.current-version }}
+          release_name: v${{ steps.package_version.outputs.current-version }}
+          body: ${{ steps.changelog_reader.outputs.changes }}
+
+      # ------------------------
+      # Upload Signed Artifact to Release
+      # ------------------------
+      - name: Upload VSIX to Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload \
+            v${{ steps.package_version.outputs.current-version }} \
+            ${{ steps.vsix.outputs.VSIX_FILE }} \
+            ${{ steps.vsix.outputs.VSIX_FILE }}.bundle
 
       # ------------------------
       # Publish to Marketplace
       # ------------------------
       - name: Publish to VS Code Marketplace
-        uses: HaaLeo/publish-vscode-extension@f4ece70f329f66686bd71c54b1671353fe320e49 # v1.7.0
+        uses: HaaLeo/publish-vscode-extension@ca5561daa085dee804bf9f37fe0165785a9b14db # v2
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           extensionFile: ${{ steps.vsix.outputs.VSIX_FILE }}
-
-      # ------------------------
-      # Create GitHub Release
-      # ------------------------
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release create "${{ github.ref_name }}" \
-            --title "${{ github.ref_name }}" \
-            --generate-notes \
-            ${{ steps.vsix.outputs.VSIX_FILE }} \
-            ${{ steps.vsix.outputs.VSIX_FILE }}.sig \
-            ${{ steps.vsix.outputs.VSIX_FILE }}.pem

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -88,13 +88,13 @@ jobs:
       # Create GitHub Release (Version Tag)
       # ------------------------
       - name: Create GitHub Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
         with:
           tag_name: v${{ steps.package_version.outputs.current-version }}
-          release_name: v${{ steps.package_version.outputs.current-version }}
+          name: v${{ steps.package_version.outputs.current-version }}
           body: ${{ steps.changelog_reader.outputs.changes }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # ------------------------
       # Upload Signed Artifact to Release


### PR DESCRIPTION
## Add signed VSIX release pipeline

This PR adds a new GitHub Actions workflow (build-and-publish.yml) to build, sign, and publish the VS Code Kubernetes Tools extension.

--- 
_**Update: 2nd March**_ - Now we now use bundle signing and also vsix is signed as artefacts using cosign thanks.

Adds a GitHub Actions workflow for releasing the VS Code extension with [Sigstore cosign](https://docs.sigstore.dev/) keyless signing. On manual trigger, the workflow:

1. Builds and packages the VSIX
2. Signs it using cosign's OIDC keyless flow (no keys to manage — identity is tied to the GitHub Actions workflow)
3. Verifies the signature before publishing
4. Creates a GitHub Release with the signed VSIX + signature bundle
5. Publishes to the VS Code Marketplace

Users can verify the VSIX authenticity with:
```sh
cosign verify-blob \
  --bundle vscode-kubernetes-tools-<version>.vsix.bundle \
  --certificate-identity-regexp "https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/" \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  vscode-kubernetes-tools-<version>.vsix
```

---

### What this does

The workflow is triggered manually via `workflow_dispatch` and performs the following steps:

1. **Build** — Checks out the repo, sets up Node.js 20, installs dependencies, and runs the build
2. **Package** — Creates a `.vsix` extension package using `vsce`
3. **Sign** — Signs the VSIX artifact using Sigstore Cosign (see details below)
4. **Release** — Creates a GitHub Release containing the VSIX, signature, and certificate
5. **Publish** — Publishes the signed extension to the VS Code Marketplace

### Cosign signing details

The pipeline uses [Sigstore Cosign](https://github.com/sigstore/cosign) in **keyless mode** to sign the `.vsix` artifact. This provides supply-chain security by cryptographically attesting that the extension was built and published from this repository's CI pipeline.

**How it works:**
- Cosign's keyless signing uses OpenID Connect (OIDC) — the GitHub Actions workflow identity token is used to prove the build's origin. No long-lived signing keys need to be created, stored, or rotated.
- The signing operation produces two artifacts alongside the VSIX:
  - **`.sig`** — The detached signature over the VSIX blob
  - **`.pem`** — The short-lived certificate (issued by Sigstore's Fulcio CA) that binds the signature to the workflow's OIDC identity
- The signature is recorded in Sigstore's [Rekor](https://github.com/sigstore/rekor) transparency log, creating a tamper-proof public record of the signing event.

### Security

- All third-party actions are **pinned to exact commit SHAs** with version comments for auditability.

❤️ As Always more eyes/thoughts and allies => Thanks all gentle cc: @tejhan, @squillace, @davidgamero, @bosesuneha, @cpuguy83, @gambtho, @ashu8912 and @DannyBrito 


![](https://media.giphy.com/media/v1.Y2lkPWVjZjA1ZTQ3MDc2YnRjYTZ3ODRpd2FyNWdrbWR2ZnhybTlzb3lzZ3ptMGM1bDgzeCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/VdyNwKWRnc6fevkYZs/giphy.gif)