### PR TITLE
Add 1es pipeline for release

### DIFF
--- a/.pipelines/1es-pipeline.yml
+++ b/.pipelines/1es-pipeline.yml
@@ -7,19 +7,14 @@ resources:
       type: git
       name: 1ESPipelineTemplates/1ESPipelineTemplates
       ref: refs/tags/release
-    - repository: vscode-kubernetes-tools
-      type: github
-      endpoint: kubernetes
-      name: vscode-kubernetes-tools/vscode-kubernetes-tools
-      ref: refs/heads/master
 
 parameters:
   - name: nodeVersion
     type: string
-    default: 22.x
+    default: 20.x
   - name: publishVersion
     type: string
-    default: 0.0.1
+    default: ""
   - name: token
     type: string
     default: ""
@@ -40,7 +35,7 @@ extends:
         hostArchitecture: amd64
       sourceRepositoriesToScan:
         include:
-          - repository: vscode-kubernetes-tools
+          - repository: self
 
     stages:
       - stage: Stage
@@ -69,7 +64,7 @@ extends:
                   packageType: "sdk"
                   version: "6.x"
 
-              - checkout: vscode-kubernetes-tools
+              - checkout: self
 
               # =====================================================
               # BUILD AND PACKAGE
@@ -84,15 +79,19 @@ extends:
               - script: npm run compile
                 displayName: Run Compile
 
-              # fail fast if the caller-supplied publishVersion
-              # doesn't match package.json.
+              # fail fast if publishVersion is empty or doesn't match package.json.
               - script: |
                   set -e
+                  PUBLISH_VER="${{ parameters.publishVersion }}"
+                  if [ -z "$PUBLISH_VER" ]; then
+                    echo "publishVersion parameter is empty. Pass the version to release, e.g. 1.3.29" >&2
+                    exit 1
+                  fi
                   PKG_VER=$(node -p "require('./package.json').version")
                   echo "package.json version: $PKG_VER"
-                  echo "publishVersion param: ${{ parameters.publishVersion }}"
-                  if [ "$PKG_VER" != "${{ parameters.publishVersion }}" ]; then
-                    echo "Mismatch: package.json ($PKG_VER) != publishVersion (${{ parameters.publishVersion }})" >&2
+                  echo "publishVersion param: $PUBLISH_VER"
+                  if [ "$PKG_VER" != "$PUBLISH_VER" ]; then
+                    echo "Mismatch: package.json ($PKG_VER) != publishVersion ($PUBLISH_VER)" >&2
                     exit 1
                   fi
                 displayName: "Verify publishVersion matches package.json"
@@ -190,10 +189,10 @@ extends:
                 displayName: "Create GitHub Release"
                 inputs:
                   gitHubConnection: Kubernetes (9)
-                  repositoryName: vscode-kubernetes-tools/vscode-kubernetes-tools
+                  repositoryName: $(Build.Repository.Name)
                   action: create
                   title: ${{ parameters.publishVersion }}
                   tagSource: userSpecifiedTag
                   tag: ${{ parameters.publishVersion }}
                   assets: |
-                    $(Pipeline.Workspace)/vscode-extension-staging/vscode-kubernetes-tools-*.vsix
+                    $(Pipeline.Workspace)/vscode-extension-staging/vscode-kubernetes-tools-${{ parameters.publishVersion }}.vsix

--- a/.pipelines/1es-pipeline.yml
+++ b/.pipelines/1es-pipeline.yml
@@ -185,14 +185,3 @@ extends:
                 env:
                   TOKEN: ${{ parameters.token }}
 
-              - task: GithubRelease@1
-                displayName: "Create GitHub Release"
-                inputs:
-                  gitHubConnection: Kubernetes (9)
-                  repositoryName: $(Build.Repository.Name)
-                  action: create
-                  title: ${{ parameters.publishVersion }}
-                  tagSource: userSpecifiedTag
-                  tag: ${{ parameters.publishVersion }}
-                  assets: |
-                    $(Pipeline.Workspace)/vscode-extension-staging/vscode-kubernetes-tools-${{ parameters.publishVersion }}.vsix

--- a/.pipelines/1es-pipeline.yml
+++ b/.pipelines/1es-pipeline.yml
@@ -1,0 +1,199 @@
+trigger: none
+
+# The `resources` specify the location and version of the 1ES PT.
+resources:
+  repositories:
+    - repository: 1esPipelines
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+    - repository: vscode-kubernetes-tools
+      type: github
+      endpoint: kubernetes
+      name: vscode-kubernetes-tools/vscode-kubernetes-tools
+      ref: refs/heads/master
+
+parameters:
+  - name: nodeVersion
+    type: string
+    default: 22.x
+  - name: publishVersion
+    type: string
+    default: 0.0.1
+  - name: token
+    type: string
+    default: ""
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  parameters:
+    pool:
+      name: staging-pool-amd64-mariner-2
+      image: 1es-azlinux-3-amd64-custom-disk
+      os: linux
+      hostArchitecture: amd64
+    sdl:
+      sourceAnalysisPool:
+        name: staging-pool-amd64-mariner-2
+        image: azcu-agent-amd64-windows-22-img
+        os: windows
+        hostArchitecture: amd64
+      sourceRepositoriesToScan:
+        include:
+          - repository: vscode-kubernetes-tools
+
+    stages:
+      - stage: Stage
+        jobs:
+          - job: HostJob
+            templateContext:
+              outputs:
+                - output: pipelineArtifact
+                  targetPath: $(Pipeline.Workspace)/vscode-extension-staging
+                  artifactName: vscode-extension-signed
+            steps:
+              # =====================================================
+              # PREREQUISITES
+              # =====================================================
+
+              - task: NodeTool@0
+                displayName: Install Node.js
+                retryCountOnTaskFailure: 3
+                inputs:
+                  versionSpec: ${{ parameters.nodeVersion }}
+
+              # .NET SDK required by EsrpCodeSigning@5 task.
+              - task: UseDotNet@2
+                displayName: Install .NET SDK (required for ESRP signing)
+                inputs:
+                  packageType: "sdk"
+                  version: "6.x"
+
+              - checkout: vscode-kubernetes-tools
+
+              # =====================================================
+              # BUILD AND PACKAGE
+              # =====================================================
+
+              - script: npm ci
+                displayName: Install npm dependencies (npm ci)
+
+              - script: npm run lint
+                displayName: Run ESLint
+
+              - script: npm run compile
+                displayName: Run Compile
+
+              # fail fast if the caller-supplied publishVersion
+              # doesn't match package.json.
+              - script: |
+                  set -e
+                  PKG_VER=$(node -p "require('./package.json').version")
+                  echo "package.json version: $PKG_VER"
+                  echo "publishVersion param: ${{ parameters.publishVersion }}"
+                  if [ "$PKG_VER" != "${{ parameters.publishVersion }}" ]; then
+                    echo "Mismatch: package.json ($PKG_VER) != publishVersion (${{ parameters.publishVersion }})" >&2
+                    exit 1
+                  fi
+                displayName: "Verify publishVersion matches package.json"
+
+              - script: |
+                  set -e
+                  echo "Generating VSIX package with pinned vsce..."
+                  npx --yes @vscode/vsce@3.9.1 --version
+                  npx --yes @vscode/vsce@3.9.1 package
+                displayName: "Generate VSIX"
+
+              # Find and copy the VSIX to the workspace dir.
+              - script: |
+                  set -e
+                  echo "Finding .vsix file..."
+                  VSIX_PATH=$(find . -maxdepth 2 -type f -name "*.vsix" -print -quit)
+
+                  if [ -z "$VSIX_PATH" ]; then
+                    echo "No .vsix file found!" >&2
+                    exit 1
+                  fi
+
+                  echo "Found: $VSIX_PATH"
+                  mkdir -p "$(Pipeline.Workspace)/vscode-extension-staging"
+                  cp "$VSIX_PATH" "$(Pipeline.Workspace)/vscode-extension-staging/"
+                displayName: "Copy VSIX to staging directory"
+
+              - script: ls -la "$(Pipeline.Workspace)/vscode-extension-staging"
+                displayName: "List staging directory"
+
+              # =====================================================
+              # MANIFEST GENERATION AND SIGNING
+              # =====================================================
+
+              - pwsh: |
+                  $vsixFile = Get-ChildItem "$(Pipeline.Workspace)/vscode-extension-staging/*.vsix" | Select-Object -First 1
+                  Write-Host "Generating manifest for: $($vsixFile.FullName)"
+                  npx --yes '@vscode/vsce@3.9.1' generate-manifest -i $vsixFile.FullName -o "$(Pipeline.Workspace)/vscode-extension-staging/extension.manifest"
+                displayName: "Generate extension manifest"
+
+              - pwsh: |
+                  Copy-Item "$(Pipeline.Workspace)/vscode-extension-staging/extension.manifest" "$(Pipeline.Workspace)/vscode-extension-staging/extension.signature.p7s"
+                  Write-Host "Prepared manifest for signing"
+                displayName: "Prepare manifest for signing"
+
+              - task: EsrpCodeSigning@5
+                displayName: Sign extension manifest with ESRP
+                inputs:
+                  ConnectedServiceName: "ESRP-AME-AZCU"
+                  UseMSIAuthentication: true
+                  AppRegistrationClientId: "70ebf75b-d46f-46da-90e6-1fa654251514"
+                  AppRegistrationTenantId: "33e01921-4d64-4f8c-a055-5bdaffd5e33d"
+                  EsrpClientId: "150f8d2b-ad88-4a27-b782-c9bc3b028430"
+                  AuthAKVName: "upstreamci-ado"
+                  AuthSignCertName: "azcu-ersp-corp"
+                  FolderPath: $(Pipeline.Workspace)/vscode-extension-staging
+                  Pattern: "extension.signature.p7s"
+                  signConfigType: inlineSignParams
+                  inlineOperation: |
+                    [
+                      {
+                        "keyCode": "CP-401405",
+                        "operationSetCode": "VSCodePublisherSign",
+                        "parameters": [],
+                        "toolName": "sign",
+                        "toolVersion": "1.0"
+                      }
+                    ]
+                  SessionTimeout: 90
+                  MaxConcurrency: 25
+                  MaxRetryAttempts: 5
+                  PendingAnalysisWaitTimeoutMinutes: 5
+
+              - script: ls -la "$(Pipeline.Workspace)/vscode-extension-staging"
+                displayName: "List staging directory (post-sign)"
+
+              - task: Bash@3
+                displayName: "Publish VSIX to Marketplace (vsce@3.9.1)"
+                inputs:
+                  targetType: inline
+                  script: |
+                    set -e
+                    npx --yes @vscode/vsce@3.9.1 --version
+
+                    VSIX_PATH=$(find "$(Pipeline.Workspace)/vscode-extension-staging/" -type f -name "*.vsix" | head -n 1)
+                    MANIFEST_PATH="$(Pipeline.Workspace)/vscode-extension-staging/extension.manifest"
+                    SIGNATURE_PATH="$(Pipeline.Workspace)/vscode-extension-staging/extension.signature.p7s"
+
+                    echo "Publishing VSIX package: $VSIX_PATH"
+                    npx --yes @vscode/vsce@3.9.1 publish --pat "$TOKEN" --packagePath "$VSIX_PATH" --manifestPath "$MANIFEST_PATH" --signaturePath "$SIGNATURE_PATH"
+                env:
+                  TOKEN: ${{ parameters.token }}
+
+              - task: GithubRelease@1
+                displayName: "Create GitHub Release"
+                inputs:
+                  gitHubConnection: Kubernetes (9)
+                  repositoryName: vscode-kubernetes-tools/vscode-kubernetes-tools
+                  action: create
+                  title: ${{ parameters.publishVersion }}
+                  tagSource: userSpecifiedTag
+                  tag: ${{ parameters.publishVersion }}
+                  assets: |
+                    $(Pipeline.Workspace)/vscode-extension-staging/vscode-kubernetes-tools-*.vsix


### PR DESCRIPTION
This pull request introduces a new pipeline configuration for the project by adding the `.pipelines/1es-pipeline.yml` file. The pipeline automates building, packaging, signing, and publishing the VS Code Kubernetes Tools extension, as well as creating a GitHub release. The configuration leverages 1ES Pipeline Templates and integrates several build and security best practices.

The most important changes are:

**Pipeline Setup and Build Automation:**
* Added `.pipelines/1es-pipeline.yml` to define a comprehensive CI/CD pipeline using 1ES Pipeline Templates, specifying resources, parameters, and build pools for both Linux and Windows environments.
* Automated build steps including installing Node.js and .NET SDK, restoring dependencies, linting, compiling the extension, and packaging it into a VSIX file.

**Validation and Security:**
* Implemented a validation step to ensure the `publishVersion` parameter matches the version in `package.json`, preventing accidental version mismatches during publishing.
* Integrated ESRP code signing for the extension manifest to enhance security and trustworthiness of the published package.

**Publishing and Release Automation:**
* Automated publishing of the signed VSIX package to the VS Code Marketplace using a provided token, and added a step to create a corresponding GitHub Release with the packaged extension as an asset. ([.pipelines/1es-pipeline.ymlR1-R199](diffhunk://#diff-4474f022769a1e140a2d183d661dc37f14724befcb7561e950ce76bdf3371ebaR1-R199)