### PR TITLE
Updating Python debugger to use ms-python.debugpy & updating extensio…

### DIFF
--- a/src/components/cloudprovider/aksprovider.ts
+++ b/src/components/cloudprovider/aksprovider.ts
@@ -3,6 +3,7 @@ import * as vscode from "vscode";
 import { longRunning } from "../../utils/notification";
 import { TokenCredential } from "@azure/core-auth";
 import { ContainerServiceClient } from "@azure/arm-containerservice";
+import { waitForExtension } from "../../extensionUtils";
 
 export class AKSProvider implements CloudProvider {
     private provider = new VSCodeAzureSubscriptionProvider();
@@ -201,21 +202,4 @@ export class AKSProvider implements CloudProvider {
         }
     }
 
-}
-
-async function waitForExtension(extensionId: string): Promise<boolean> {
-    return new Promise((resolve) => {
-        const interval = setInterval(() => {
-            const extension = vscode.extensions.getExtension(extensionId);
-            if (extension) {
-                clearInterval(interval);
-                resolve(true);
-            }
-        }, 1000);
-
-        setTimeout(() => {
-            clearInterval(interval);
-            resolve(false);
-        }, 60000); // Wait for up to 60 seconds
-    });
 }

--- a/src/debug/pythonDebugProvider.ts
+++ b/src/debug/pythonDebugProvider.ts
@@ -9,10 +9,9 @@ import { Kubectl } from "../kubectl";
 import { kubeChannel } from "../kubeChannel";
 import { ProcessInfo } from "./debugUtils";
 import { ExecResult } from "../binutilplusplus";
-import * as extensionConfig from '../components/config/config';
 
 const debuggerType = 'python';
-const defaultPythonDebuggerExtensionId = 'ms-python.python';
+const debugpyExtensionId = 'ms-python.debugpy';
 
 export class PythonDebugProvider implements IDebugProvider {
     remoteRoot: string | undefined;
@@ -23,25 +22,26 @@ export class PythonDebugProvider implements IDebugProvider {
     }
 
     public async isDebuggerInstalled(): Promise<boolean> {
-        if (vscode.extensions.getExtension(defaultPythonDebuggerExtensionId)) {
+        // The "python" debugger type is deprecated; debugpy is now required.
+        if (vscode.extensions.getExtension(debugpyExtensionId)) {
             return true;
         }
-        const answer = await vscode.window.showInformationMessage(`Python debugging requires the '${defaultPythonDebuggerExtensionId}' extension. Would you like to install it now?`, "Install Now");
+        const answer = await vscode.window.showInformationMessage(`Python debugging requires the '${debugpyExtensionId}' extension. Would you like to install it now?`, "Install Now");
         if (answer === "Install Now") {
-            return await extensionUtils.installVscodeExtension(defaultPythonDebuggerExtensionId);
+            return await extensionUtils.installVscodeExtension(debugpyExtensionId);
         }
         return false;
     }
 
     public async startDebugging(workspaceFolder: string, sessionName: string, port: number | undefined, _pod: string, _pidToDebug: number | undefined): Promise<boolean> {
         const debugConfiguration: vscode.DebugConfiguration = {
-            type: "python",
+            type: "debugpy",
             request: "attach",
             name: sessionName,
-            hostName: "localhost",
+            host: "localhost",
             port
         };
-        debugConfiguration.justMyCode = extensionConfig.getDebugJustMyCode();
+        debugConfiguration.justMyCode = config.getDebugJustMyCode();
         const currentFolder = (vscode.workspace.workspaceFolders || []).find((folder) => folder.name === path.basename(workspaceFolder));
         if (currentFolder && this.remoteRoot) {
             debugConfiguration['pathMappings'] = [{

--- a/src/extensionUtils.ts
+++ b/src/extensionUtils.ts
@@ -1,7 +1,4 @@
-import * as path from "path";
 import * as vscode from "vscode";
-
-import { shell } from "./shell";
 
 /**
  * Install a vscode extension programmatically.
@@ -9,16 +6,40 @@ import { shell } from "./shell";
  * @param extensionId the extension id.
  */
 export async function installVscodeExtension(extensionId: string): Promise<boolean> {
-    const vscodeCliPath = path.join(path.dirname(process.argv0), "bin", "code");
-    const shellResult = await shell.exec(`"${vscodeCliPath}" --install-extension ${extensionId}`);
-    if (shellResult && shellResult.code === 0) {
-        const answer = await vscode.window.showInformationMessage(`Extension '${extensionId}' was successfully installed. Reload to enable it.`, "Reload Now");
-        if (answer === "Reload Now") {
-            await vscode.commands.executeCommand("workbench.action.reloadWindow");
-            return true;
-        }
+    try {
+        await vscode.commands.executeCommand("workbench.extensions.installExtension", extensionId);
+    } catch (err) {
+        vscode.window.showErrorMessage(`Failed to install extension '${extensionId}': ${err}`);
+        return false;
+    }
+    const installed = await waitForExtension(extensionId);
+    if (!installed) {
+        vscode.window.showErrorMessage(`Extension '${extensionId}' was not available after installation.`);
+        return false;
+    }
+    const answer = await vscode.window.showInformationMessage(`Extension '${extensionId}' was successfully installed. Reload to enable it.`, "Reload Now");
+    if (answer === "Reload Now") {
+        await vscode.commands.executeCommand("workbench.action.reloadWindow");
+        return true;
     }
     return false;
+}
+
+export async function waitForExtension(extensionId: string): Promise<boolean> {
+    return new Promise((resolve) => {
+        const interval = setInterval(() => {
+            const extension = vscode.extensions.getExtension(extensionId);
+            if (extension) {
+                clearInterval(interval);
+                resolve(true);
+            }
+        }, 1000);
+
+        setTimeout(() => {
+            clearInterval(interval);
+            resolve(false);
+        }, 60000); // Wait for up to 60 seconds
+    });
 }
 
 export function isNonEmptyArray(value: any[]): boolean {


### PR DESCRIPTION
This PR Updates Python debug attach to use `debugpy` (the `python` debug type is deprecated) and updates extension installation to use VS Code's API instead of the `code` CLI for better reliability across environments, (which fixes a related silent failure of extension installation observed on WSL platforms).

### Changes

- Python debug attach now uses `type: "debugpy"`.
- Python attach config now uses `host` (replacing `hostName`).
- Python debugger check now accepts either `ms-python.debugpy` or `ms-python.python`.
- Python install prompt now installs `ms-python.debugpy`.
- Extension installation now uses the VS Code command `workbench.extensions.installExtension` instead of `code --install-extension`.
- Removed duplicate config import in the Python debug provider.



### Related Issues

- https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1817


### Steps to test

### 1. Test the extension installation prompt

1. Launch the extension & disable/remove both `ms-python.python` and `ms-python.debugpy`.
3. Select Debug (Attach) on a pod.
4. Verify the prompt offers to install `ms-python.debugpy`.
5. Click 'Install Now' & verify the extension installs successfully.

### 2. Test the Debugger

1. Ensure `ms-python.debugpy` is now enabled.
2. Run a Python pod with debugpy listening.
3. Select Debug (Attach) on the pod.
4. Verify the debug session starts successfully.


( Thank you to @cmelaro for bringing this to attention. )