### PR TITLE
Update CI workflow triggers from master to main

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -3,10 +3,10 @@ name: Development build
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
   schedule:
     - cron: '20 1 * * 0'
 


### PR DESCRIPTION
When the default branch was renamed from `master` to `main`, the PR triggers in two workflow files weren't updated and thus silently deactivated. 

This PR updates the branch to main in the build & codeql workflows so that we resume CI checks for PRs. 

