### PR TITLE
Fix Typescript 6 compilation errors

### DIFF
--- a/src/components/clusterexplorer/explorer.ts
+++ b/src/components/clusterexplorer/explorer.ts
@@ -87,7 +87,7 @@ export class KubernetesExplorer implements vscode.TreeDataProvider<ClusterExplor
 
     private readonly extenders = Array.of<ExplorerExtender<ClusterExplorerNode>>();
     private readonly customisers = Array.of<ExplorerUICustomizer<ClusterExplorerNode>>();
-    private refreshTimer: NodeJS.Timeout;
+    private refreshTimer: NodeJS.Timeout | undefined;
     private readonly refreshQueue = Array<ClusterExplorerNode>();
 
     constructor(private readonly kubectl: Kubectl, private readonly host: Host) {

--- a/src/components/clusterprovider/minikube/minikube.ts
+++ b/src/components/clusterprovider/minikube/minikube.ts
@@ -11,17 +11,17 @@ import { getToolPath, getCheckForMinikubeUpgrade, setMinikubeShowInfo } from '..
 import { installMinikube } from '../../installer/installer';
 import { isMinikubeInfoDisplay, ShowInformationOptions } from '../common/cacheinfo';
 
-export class MinikubeInfo {
+export interface MinikubeInfo {
     readonly running: boolean;
     readonly message: string;
 }
 
-export class MinikubeVersionInfo {
+export interface MinikubeVersionInfo {
     readonly currentVersion: string;
     readonly availableVersion: string;
 }
 
-export class MinikubeOptions {
+export interface MinikubeOptions {
     readonly vmDriver: string;
     readonly additionalFlags: string;
 }

--- a/src/debug/debugSession.ts
+++ b/src/debug/debugSession.ts
@@ -127,7 +127,7 @@ export class DebugSession implements IDebugSession {
                     await this.promptForCleanup(`deployment/${appName}`);
                 });
             } catch (error) {
-                vscode.window.showErrorMessage(error);
+                vscode.window.showErrorMessage(String(error));
                 kubeChannel.showOutput(`Debug on Kubernetes failed. The errors were: ${error}.`);
                 if (appName) {
                     await this.promptForCleanup(`deployment/${appName}`);
@@ -202,7 +202,7 @@ export class DebugSession implements IDebugSession {
 
                 await this.startDebugSession(targetPod, workspaceFolder.uri.fsPath, proxyResult, targetPod, pidToDebug, async () => {});
             } catch (error) {
-                vscode.window.showErrorMessage(error);
+                vscode.window.showErrorMessage(String(error));
                 kubeChannel.showOutput(`Debug on Kubernetes failed. The errors were: ${error}.`);
                 kubeChannel.showOutput(`\nTo learn more about the usage of the debug feature, take a look at ${debugCommandDocumentationUrl}`);
             }

--- a/src/debug/dotNetDebugProvider.ts
+++ b/src/debug/dotNetDebugProvider.ts
@@ -52,7 +52,7 @@ export class DotNetDebugProvider implements IDebugProvider {
                 const sourceFileMap: JSON = JSON.parse(json);
                 debugConfiguration['sourceFileMap'] = sourceFileMap;
             } catch (error) {
-                kubeChannel.showOutput(error.message);
+                kubeChannel.showOutput(error instanceof Error ? error.message : String(error));
             }
         }
         debugConfiguration.justMyCode = extensionConfig.getDebugJustMyCode();

--- a/src/debug/nodejsDebugProvider.ts
+++ b/src/debug/nodejsDebugProvider.ts
@@ -17,7 +17,7 @@ const debuggerType = 'nodejs';
 
 export class NodejsDebugProvider implements IDebugProvider {
     remoteRoot: string | undefined;
-    shell: string;
+    shell: string = "";
 
     public getDebuggerType(): string {
         return debuggerType;

--- a/src/debug/pythonDebugProvider.ts
+++ b/src/debug/pythonDebugProvider.ts
@@ -16,7 +16,7 @@ const defaultPythonDebuggerExtensionId = 'ms-python.python';
 
 export class PythonDebugProvider implements IDebugProvider {
     remoteRoot: string | undefined;
-    shell: string;
+    shell: string = "";
 
     public getDebuggerType(): string {
         return debuggerType;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1033,8 +1033,9 @@ function buildPushThenExec(fn: (name: string, image: string) => void): void {
                     console.log(buildResult.stderr);
                 }
             } catch (err) {
-                vscode.window.showErrorMessage(err.message);
-                kubeChannel.showOutput(`Failed building/pushing an image: ${err}`);
+                const errorMessage = err instanceof Error ? err.message : String(err);
+                vscode.window.showErrorMessage(errorMessage);
+                kubeChannel.showOutput(`Failed building/pushing an image: ${errorMessage}`);
             }
         });
     });
@@ -1091,7 +1092,7 @@ function findKindNamesForText(text: string): Errorable<ResourceKindName[]> {
         return { succeeded: true, result: kindNames };
     } catch (ex) {
         console.log(ex);
-        return { succeeded: false, error: [ ex ] };
+        return { succeeded: false, error: [ String(ex) ] };
     }
 }
 

--- a/src/helm.completionProvider.ts
+++ b/src/helm.completionProvider.ts
@@ -13,7 +13,7 @@ export class HelmTemplateCompletionProvider implements vscode.CompletionItemProv
     private funcmap = new FuncMap();
 
     private valuesCache: any;  // pulled in from YAML, no schema
-    private valuesWatcher: vscode.FileSystemWatcher;
+    private valuesWatcher: vscode.FileSystemWatcher | undefined;
 
     public constructor() {
         // The extension activates on things like 'Kubernetes tree visible',
@@ -45,7 +45,7 @@ export class HelmTemplateCompletionProvider implements vscode.CompletionItemProv
         try {
             this.valuesCache = YAML.load(valsYaml);
         } catch (err) {
-            logger.helm.log(err.message);
+            logger.helm.log(err instanceof Error ? err.message : String(err));
             return;
         }
     }
@@ -96,7 +96,7 @@ export class HelmTemplateCompletionProvider implements vscode.CompletionItemProv
             try {
                 reExecResult = this.valuesMatcher.exec(lineUntil);
             } catch (err) {
-                logger.helm.log(err.message);
+                logger.helm.log(err instanceof Error ? err.message : String(err));
                 return [];
             }
 

--- a/src/helm.documentProvider.ts
+++ b/src/helm.documentProvider.ts
@@ -205,7 +205,8 @@ export class HelmTemplatePreviewDocumentProvider implements vscode.TextDocumentC
                             } catch (e) {
                                 // TODO: Figure out the best way to display this message, but have it go away when the
                                 // file parses correctly.
-                                vscode.window.showErrorMessage(`YAML failed to parse: ${ e.message }`);
+                                const errorMessage = e instanceof Error ? e.message : String(e);
+                                vscode.window.showErrorMessage(`YAML failed to parse: ${ errorMessage }`);
                             }
                         }
 

--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -683,10 +683,10 @@ function quickPickForChart(chartUri: vscode.Uri): vscode.QuickPickItem & { reado
     };
 }
 
-class Chart {
-    public name: string;
-    public version: string;
-    public appVersion: string;
+interface Chart {
+    name: string;
+    version: string;
+    appVersion: string;
 }
 
 // Load a chart object
@@ -883,9 +883,9 @@ function handleHelmNotFoundError(mode:EnsureMode, message:string): boolean{
 }
 
 export class Requirement {
-    public repository: string;
-    public name: string;
-    public version: string;
+    public repository: string = "";
+    public name: string = "";
+    public version: string = "";
     toString(): string {
         return `- name: ${this.name}
   version: ${ this.version }

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -143,7 +143,7 @@ async function exec(cmd: string, stdin?: string): Promise<ShellResult | undefine
     try {
         return await execCore(cmd, execOpts(), null, stdin);
     } catch (ex) {
-        vscode.window.showErrorMessage(ex);
+        vscode.window.showErrorMessage(String(ex));
         return undefined;
     }
 }
@@ -152,7 +152,7 @@ async function execStreaming(cmd: string, callback: (proc: ChildProcess) => void
     try {
         return await execCore(cmd, execOpts(), callback);
     } catch (ex) {
-        vscode.window.showErrorMessage(ex);
+        vscode.window.showErrorMessage(String(ex));
         return undefined;
     }
 }

--- a/src/utils/containercontainer.ts
+++ b/src/utils/containercontainer.ts
@@ -13,7 +13,7 @@ export interface ContainerContainer {
     readonly containersQueryPath: string;
 }
 
-export module ContainerContainer {
+export namespace ContainerContainer {
 
     export function fromNode(explorerNode: ClusterExplorerResourceNode): ContainerContainer | undefined {
         const queryPath = containersQueryPath(explorerNode);

--- a/src/utils/dictionary.ts
+++ b/src/utils/dictionary.ts
@@ -2,7 +2,7 @@ export type Dictionary<T> = {
     [key: string]: T;
 };
 
-export module Dictionary {
+export namespace Dictionary {
     export function of<T>(): Dictionary<T> {
         return {};
     }

--- a/src/yaml-support/schema-holder.ts
+++ b/src/yaml-support/schema-holder.ts
@@ -22,8 +22,8 @@ interface KubernetesSchema {
 
 export class KubernetesClusterSchemaHolder {
     private definitions: { [key: string]: KubernetesSchema } = {};
-    private schemaEnums: { [key: string]: { [key: string]: [string[]] } };
-    private crdSchemas: { [key: string]: object | undefined};
+    private schemaEnums: { [key: string]: { [key: string]: [string[]] } } = {};
+    private crdSchemas: { [key: string]: object | undefined } = {};
 
     public static async fromActiveCluster(kubectl: Kubectl): Promise<KubernetesClusterSchemaHolder> {
         const holder = new KubernetesClusterSchemaHolder();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
         "module": "commonjs",
         "target": "es6",
         "outDir": "out",
-        "moduleResolution": "node10",
+        "moduleResolution": "bundler",
         "lib": [
             "es6"
         ],


### PR DESCRIPTION
We had an earlier dependabot PR (#1862) that bumped TypeScript from 5.9.3 to 6.0.2. 
 
 This being a major version update, 31 errors were surfaced. These were silenced in the original PR due to a change in branch naming that caused the CI checks to go untriggered. 
 
 Changes (per error type):
 
- Resolved 18 uninitialized class property errors. Initialized some fields with defaults (`= {}`, `= ""`, etc.), widening types (`| undefined`) for some, & converting some sparse classes to interfaces.
- Resolved 10 `unknown` errors with `(e as Error).message` or `String(e)` casting
- Renamed 2 deprecated `module` keywords to `namespace`
- Swapped deprecated `node10` in `moduleResolution: node10` to `bundler`

This resolves all current build errors on the repo.