### PR TITLE
Adding distingishuable icons for spawned terminals

### DIFF
--- a/src/components/kubectl/events.ts
+++ b/src/components/kubectl/events.ts
@@ -1,3 +1,4 @@
+import { ThemeIcon } from 'vscode';
 import { Kubectl } from '../../kubectl';
 import * as kubectlUtils from '../../kubectlUtils';
 import { ClusterExplorerResourceNode } from '../clusterexplorer/node';
@@ -20,7 +21,7 @@ export async function getEvents(kubectl: Kubectl, displayMode: EventDisplayMode,
 
     if (displayMode === EventDisplayMode.Follow) {
         cmd += ' -w';
-        return kubectl.invokeInNewTerminal(cmd, 'Kubernetes Events');
+        return kubectl.invokeInNewTerminal(cmd, 'Kubernetes Events', undefined, undefined, new ThemeIcon('bell'));
     } else {
         return kubectl.invokeInSharedTerminal(cmd);
     }

--- a/src/components/kubectl/logs.ts
+++ b/src/components/kubectl/logs.ts
@@ -128,7 +128,7 @@ export async function getLogsForContainer(
     if (destination === LogsDestination.Terminal) {
         if (displayMode === LogsDisplayMode.Follow) {
             const title = `Logs: ${kindName}${containerName ? ('/' + containerName) : ''}`;
-            kubectl.invokeInNewTerminal(cmd, title);
+            kubectl.invokeInNewTerminal(cmd, title, undefined, undefined, new vscode.ThemeIcon('output'));
         } else {
             kubectl.invokeInSharedTerminal(cmd);
         }

--- a/src/components/kubectl/port-forward.ts
+++ b/src/components/kubectl/port-forward.ts
@@ -4,7 +4,7 @@ import { Kubectl } from '../../kubectl';
 
 import { host } from '../../host';
 import { findAllPods, tryFindKindNameFromEditor, FindPodsResult } from '../../extension';
-import { QuickPickOptions } from 'vscode';
+import { QuickPickOptions, ThemeIcon } from 'vscode';
 import * as portFinder from 'portfinder';
 import { succeeded } from '../../errorable';
 import * as kubectlUtils from '../../kubectlUtils';
@@ -420,7 +420,7 @@ async function portForwardToResource(kubectl: Kubectl, kind: string, name: strin
         (usedPortPair) => `${usedPortPair.localPort}:${usedPortPair.targetPort}`
     );
 
-    kubectl.invokeInNewTerminal(`port-forward ${kind}/${name} ${portPairStrings.join(' ')} -n ${usedNamespace}`, PORT_FORWARD_TERMINAL);
+    kubectl.invokeInNewTerminal(`port-forward ${kind}/${name} ${portPairStrings.join(' ')} -n ${usedNamespace}`, PORT_FORWARD_TERMINAL, undefined, undefined, new ThemeIcon('plug'));
     return usedPortMappings.choose((usedPortPair) => usedPortPair.localPort);
 }
 

--- a/src/host.ts
+++ b/src/host.ts
@@ -12,7 +12,7 @@ export interface Host {
     showQuickPick<T extends vscode.QuickPickItem>(items: T[], options: vscode.QuickPickOptions): Thenable<T | undefined>;
     withProgress<R>(task: (progress: vscode.Progress<{ message?: string }>) => Thenable<R>): Thenable<R>;
     getConfiguration(key: string): any;
-    createTerminal(name?: string, shellPath?: string, shellArgs?: string[]): vscode.Terminal;
+    createTerminal(name?: string, shellPath?: string, shellArgs?: string[], iconPath?: vscode.ThemeIcon): vscode.Terminal;
     onDidCloseTerminal(listener: (e: vscode.Terminal) => any): vscode.Disposable;
     onDidChangeConfiguration(listener: (ch: vscode.ConfigurationChangeEvent) => any): vscode.Disposable;
     activeDocument(): vscode.TextDocument | undefined;
@@ -94,12 +94,13 @@ function getConfiguration(key: string): any {
     return vscode.workspace.getConfiguration(key);
 }
 
-function createTerminal(name?: string, shellPath?: string, shellArgs?: string[]): vscode.Terminal {
+function createTerminal(name?: string, shellPath?: string, shellArgs?: string[], iconPath?: vscode.ThemeIcon): vscode.Terminal {
     const terminalOptions = {
         name: name,
         shellPath: shellPath,
         shellArgs: shellArgs,
-        env: shellEnvironment(process.env)
+        env: shellEnvironment(process.env),
+        iconPath: iconPath
     };
     return vscode.window.createTerminal(terminalOptions);
 }

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -1,4 +1,4 @@
-import { Terminal, Disposable } from 'vscode';
+import { Terminal, Disposable, ThemeIcon } from 'vscode';
 import { ChildProcess, spawn as spawnChildProcess } from "child_process";
 import { Host, host, LongRunningUIOptions } from './host';
 import { FS } from './fs';
@@ -20,7 +20,7 @@ export interface Kubectl {
     legacyInvokeAsync(command: string, stdin?: string): Promise<ShellResult | undefined>;
     legacySpawnAsChild(command: string[]): Promise<ChildProcess | undefined>;
 
-    invokeInNewTerminal(command: string, terminalName: string, onClose?: (e: Terminal) => any, pipeTo?: string): Promise<Disposable>;
+    invokeInNewTerminal(command: string, terminalName: string, onClose?: (e: Terminal) => any, pipeTo?: string, iconPath?: ThemeIcon): Promise<Disposable>;
     invokeInSharedTerminal(command: string): Promise<void>;
     runAsTerminal(command: string[], terminalName: string): Promise<void>;
 
@@ -124,8 +124,8 @@ class KubectlImpl implements Kubectl {
             }
         });
     }
-    async invokeInNewTerminal(command: string, terminalName: string, onClose?: (e: Terminal) => any, pipeTo?: string): Promise<Disposable> {
-        const terminal = this.context.host.createTerminal(terminalName);
+    async invokeInNewTerminal(command: string, terminalName: string, onClose?: (e: Terminal) => any, pipeTo?: string, iconPath?: ThemeIcon): Promise<Disposable> {
+        const terminal = this.context.host.createTerminal(terminalName, undefined, undefined, iconPath);
         const disposable = this.context.host.onDidCloseTerminal(onClose ? onClose : onCloseDefault(terminal.processId));
         await invokeInTerminal(this.context, command, pipeTo, terminal);
         return disposable;


### PR DESCRIPTION
Added distinct icons to terminals spawned by long-running commands (ex. Port forwards, following logs, following events), which will help users more easily identify stacked tabs at a glance. 

- Added `plug` `ThemeIcon` to Port Forwarding terminal invokation
- Added `bell` `ThemeIcon` to Following Events terminal invokation
- Added `output` `ThemeIcon` to Following Logs terminal invokation


Related Issue:

- https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1810