### PR TITLE
Update OWNERS.md - maintainer list changes

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -13,10 +13,11 @@ The following people are current maintainers of the Kubernetes extension project
 **Current:**
 
 * [Tatsat Mishra (Tats)](https://github.com/Tatsinnit)
-* [Reinier Cruz](https://github.com/ReinierCC)
+* ~~[Reinier Cruz](https://github.com/ReinierCC)~~
 * [Tejhan Diallo](https://github.com/tejhan)
 * ~~[Hariharan Subramanian](https://github.com/hsubramanianaks)~~
 * [Suneha Bose](https://github.com/bosesuneha)
 * [David Gamero](https://github.com/davidgamero)
-* [Quentin Petraroia](https://github.com/qpetraroia)
+* [Tom Gamble](https://github.com/gambtho)
+* ~~[Quentin Petraroia](https://github.com/qpetraroia)~~
 * [Ralph Squillace](https://github.com/squillace) - For guidance, discussions and directions.


### PR DESCRIPTION

### **Description:**

Updates the project maintainers list:

- Mark Reinier Cruz (`@ReinierCC`) as a previous maintainer
- Mark Quentin Petraroia (`@qpetraroia`) as a previous maintainer
- Add Tom Gamble (`@gambtho`) as a current maintainer

Associates with: https://github.com/cncf/foundation/pull/1392 

thanks and gentle fyi @bosesuneha , @tejhan ❤️ 