### PR TITLE
docs(owners): separate emeritus maintainers from current list

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -4,20 +4,20 @@
 
 The following people are current maintainers of the Kubernetes extension project:
 
-**Previous Active Users:**
+**Emeritus (Previous Active Users):**
 
 * ~~[Ivan Towlson](https://github.com/itowlson)~~
 * ~~[Luca Stocchi](https://github.com/lstocchi)~~
 * ~~[Bhargav Nookala](https://github.com/bnookala)~~
+* ~~[Reinier Cruz](https://github.com/ReinierCC)~~
+* ~~[Hariharan Subramanian](https://github.com/hsubramanianaks)~~
+* ~~[Quentin Petraroia](https://github.com/qpetraroia)~~
 
 **Current:**
 
 * [Tatsat Mishra (Tats)](https://github.com/Tatsinnit)
-* ~~[Reinier Cruz](https://github.com/ReinierCC)~~
 * [Tejhan Diallo](https://github.com/tejhan)
-* ~~[Hariharan Subramanian](https://github.com/hsubramanianaks)~~
 * [Suneha Bose](https://github.com/bosesuneha)
 * [David Gamero](https://github.com/davidgamero)
 * [Tom Gamble](https://github.com/gambtho)
-* ~~[Quentin Petraroia](https://github.com/qpetraroia)~~
 * [Ralph Squillace](https://github.com/squillace) - For guidance, discussions and directions.


### PR DESCRIPTION
### Description

**What**

Reorganize OWNERS.md to clearly distinguish emeritus maintainers from currently active ones.

This change originates form the kind recommendation here: https://github.com/cncf/foundation/pull/1392 , thank you all. ❤️ 

**Changes**
- Renamed the **Previous Active Users** section to **Emeritus (Previous Active Users)** for clarity.
- Moved the following maintainers from **Current** into the Emeritus section:
  - [Reinier Cruz](https://github.com/ReinierCC)
  - [Hariharan Subramanian](https://github.com/hsubramanianaks)
  - [Quentin Petraroia](https://github.com/qpetraroia)
- The **Current** list now reflects only active maintainers.

**Why**
The previous layout mixed struck-through (inactive) names within the Current maintainers list, which was confusing. Grouping emeritus maintainers together makes the active maintainer set easy to identify at a glance.

**Impact**
Documentation-only change — no code, build, or runtime impact.