### PR TITLE
Ability to Restart Resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -634,6 +634,11 @@
                     "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.resource\\.(deployment|job|rc|rs|statefulset)/i"
                 },
                 {
+                    "command": "extension.vsKubernetesRestart",
+                    "group": "2@7",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.resource\\.(deployment|statefulset|daemonset)/i"
+                },
+                {
                     "command": "extension.vsKubernetesLogs",
                     "group": "inline",
                     "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.resource\\.(pod|job)/i"
@@ -915,6 +920,11 @@
             {
                 "command": "extension.vsKubernetesScale",
                 "title": "Scale",
+                "category": "Kubernetes"
+            },
+            {
+                "command": "extension.vsKubernetesRestart",
+                "title": "Restart",
                 "category": "Kubernetes"
             },
             {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1000,8 +1000,15 @@ async function restartKubernetes(target?: any) {
 }
 
 async function invokeRestartKubernetes(kindName: string, namespace: string) {
+    const trimmedNamespace = (namespace || '').trim();
+    if (trimmedNamespace.toLowerCase() === 'all') {
+        vscode.window.showErrorMessage('Restart is not supported across all namespaces. Please select a specific namespace.');
+        return;
+    }
+
+    const namespaceArg = trimmedNamespace ? ` --namespace=${trimmedNamespace}` : '';
     const er = await host.longRunning(`Restarting ${kindName}...`, () =>
-        kubectl.invokeCommand(`rollout restart ${kindName} --namespace=${namespace}`)
+        kubectl.invokeCommand(`rollout restart ${kindName}${namespaceArg}`)
     );
     await kubectl.reportResult(er, {});
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -199,6 +199,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
         registerCommand('extension.vsKubernetesTerminal', terminalKubernetes),
         registerCommand('extension.vsKubernetesDiff', diffKubernetes),
         registerCommand('extension.vsKubernetesScale', scaleKubernetes),
+        registerCommand('extension.vsKubernetesRestart', restartKubernetes),
         registerCommand('extension.vsKubernetesDebug', debugKubernetes),
         registerCommand('extension.vsKubernetesRemoveDebug', removeDebugKubernetes),
         registerCommand('extension.vsKubernetesDebugAttach', debugAttachKubernetes),
@@ -979,6 +980,28 @@ function promptScaleKubernetes(kindName: string) {
 async function invokeScaleKubernetes(kindName: string, replicas: number) {
     const er = await host.longRunning(`Scaling ${kindName} to ${replicas} replicas...`, () =>
         kubectl.invokeCommand(`scale --replicas=${replicas} ${kindName}`)
+    );
+    await kubectl.reportResult(er, {});
+}
+
+async function restartKubernetes(target?: any) {
+    if (target && explorer.isKubernetesExplorerResourceNode(target)) {
+        const kindName = target.kindName;
+        const namespace = target.namespace || await kubectlUtils.currentNamespace(kubectl);
+        await invokeRestartKubernetes(kindName, namespace);
+    } else {
+        const isMinimalWorkflow = config.isMinimalWorkflow();
+        const kindName = await findKindNameOrPrompt(kuberesources.restartableKinds, 'restart', { skipFreeTextPrompt: isMinimalWorkflow });
+        if (kindName) {
+            const namespace = await kubectlUtils.currentNamespace(kubectl);
+            await invokeRestartKubernetes(kindName, namespace);
+        }
+    }
+}
+
+async function invokeRestartKubernetes(kindName: string, namespace: string) {
+    const er = await host.longRunning(`Restarting ${kindName}...`, () =>
+        kubectl.invokeCommand(`rollout restart ${kindName} --namespace=${namespace}`)
     );
     await kubectl.reportResult(er, {});
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -990,8 +990,7 @@ async function restartKubernetes(target?: any) {
         const namespace = target.namespace || await kubectlUtils.currentNamespace(kubectl);
         await invokeRestartKubernetes(kindName, namespace);
     } else {
-        const isMinimalWorkflow = config.isMinimalWorkflow();
-        const kindName = await findKindNameOrPrompt(kuberesources.restartableKinds, 'restart', { skipFreeTextPrompt: isMinimalWorkflow });
+        const kindName = await findKindNameOrPrompt(kuberesources.restartableKinds, 'restart', { skipFreeTextPrompt: true });
         if (kindName) {
             const namespace = await kubectlUtils.currentNamespace(kubectl);
             await invokeRestartKubernetes(kindName, namespace);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -991,10 +991,6 @@ async function restartKubernetes(target?: any) {
         await invokeRestartKubernetes(kindName, namespace);
     } else {
         const namespace = await kubectlUtils.currentNamespace(kubectl);
-        if (namespace.trim().toLowerCase() === 'all') {
-            vscode.window.showErrorMessage('Restart is not supported across all namespaces. Please select a specific namespace.');
-            return;
-        }
         const kindName = await findKindNameOrPrompt(kuberesources.restartableKinds, 'restart', { skipFreeTextPrompt: config.isMinimalWorkflow() });
         if (kindName) {
             await invokeRestartKubernetes(kindName, namespace);
@@ -1004,10 +1000,6 @@ async function restartKubernetes(target?: any) {
 
 async function invokeRestartKubernetes(kindName: string, namespace: string) {
     const trimmedNamespace = namespace.trim();
-    if (trimmedNamespace.toLowerCase() === 'all') {
-        vscode.window.showErrorMessage('Restart is not supported across all namespaces. Please select a specific namespace.');
-        return;
-    }
 
     const namespaceArg = trimmedNamespace ? ` --namespace=${trimmedNamespace}` : '';
     const er = await host.longRunning(`Restarting ${kindName}...`, () =>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -990,9 +990,13 @@ async function restartKubernetes(target?: any) {
         const namespace = target.namespace || await kubectlUtils.currentNamespace(kubectl);
         await invokeRestartKubernetes(kindName, namespace);
     } else {
+        const namespace = await kubectlUtils.currentNamespace(kubectl);
+        if (namespace.trim().toLowerCase() === 'all') {
+            vscode.window.showErrorMessage('Restart is not supported across all namespaces. Please select a specific namespace.');
+            return;
+        }
         const kindName = await findKindNameOrPrompt(kuberesources.restartableKinds, 'restart', { skipFreeTextPrompt: true });
         if (kindName) {
-            const namespace = await kubectlUtils.currentNamespace(kubectl);
             await invokeRestartKubernetes(kindName, namespace);
         }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -995,7 +995,7 @@ async function restartKubernetes(target?: any) {
             vscode.window.showErrorMessage('Restart is not supported across all namespaces. Please select a specific namespace.');
             return;
         }
-        const kindName = await findKindNameOrPrompt(kuberesources.restartableKinds, 'restart', { skipFreeTextPrompt: true });
+        const kindName = await findKindNameOrPrompt(kuberesources.restartableKinds, 'restart', { skipFreeTextPrompt: config.isMinimalWorkflow() });
         if (kindName) {
             await invokeRestartKubernetes(kindName, namespace);
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -999,7 +999,7 @@ async function restartKubernetes(target?: any) {
 }
 
 async function invokeRestartKubernetes(kindName: string, namespace: string) {
-    const trimmedNamespace = (namespace || '').trim();
+    const trimmedNamespace = namespace.trim();
     if (trimmedNamespace.toLowerCase() === 'all') {
         vscode.window.showErrorMessage('Restart is not supported across all namespaces. Please select a specific namespace.');
         return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -199,6 +199,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
         registerCommand('extension.vsKubernetesTerminal', terminalKubernetes),
         registerCommand('extension.vsKubernetesDiff', diffKubernetes),
         registerCommand('extension.vsKubernetesScale', scaleKubernetes),
+        registerCommand('extension.vsKubernetesRestart', restartKubernetes),
         registerCommand('extension.vsKubernetesDebug', debugKubernetes),
         registerCommand('extension.vsKubernetesRemoveDebug', removeDebugKubernetes),
         registerCommand('extension.vsKubernetesDebugAttach', debugAttachKubernetes),
@@ -981,6 +982,33 @@ async function invokeScaleKubernetes(kindName: string, replicas: number) {
         kubectl.invokeCommand(`scale --replicas=${replicas} ${kindName}`)
     );
     await kubectl.reportResult(er, {});
+}
+
+async function restartKubernetes(target?: any) {
+    if (target && explorer.isKubernetesExplorerResourceNode(target)) {
+        await invokeRestartKubernetes(target.kindName);
+    } else {
+        const kindName = await findKindNameOrPrompt(kuberesources.restartableKinds, 'restart', { skipFreeTextPrompt: config.isMinimalWorkflow() });
+        if (kindName) {
+            await invokeRestartKubernetes(kindName);
+        }
+    }
+}
+
+async function invokeRestartKubernetes(kindName: string) {
+    const confirmed = await warnConfirm(`Do you want to restart '${kindName}'? This will roll all of its pods.`, "Restart", "Cancel");
+    if (!confirmed) {
+        return;
+    }
+
+    const nsarg = await kubectlUtils.currentNamespaceArg(kubectl);
+    const er = await host.longRunning(`Restarting ${kindName}...`, () =>
+        kubectl.invokeCommand(`rollout restart ${kindName} ${nsarg}`)
+    );
+    await kubectl.reportResult(er, {});
+    if (ExecResult.succeeded(er)) {
+        refreshExplorer();
+    }
 }
 
 function runKubernetes() {

--- a/src/kuberesources.ts
+++ b/src/kuberesources.ts
@@ -46,6 +46,12 @@ export const scaleableKinds = [
     allKinds.statefulSet,
 ];
 
+export const restartableKinds = [
+    allKinds.deployment,
+    allKinds.statefulSet,
+    allKinds.daemonSet,
+];
+
 export const exposableKinds = [
     allKinds.deployment,
     allKinds.pod,


### PR DESCRIPTION
## Summary 
Currently, there is no way to quickly restart resources. The following patch adds a restart option for Deployments, StatefulSets, and DaemonSets

## Screenshots
<img width="357" height="644" alt="image" src="https://github.com/user-attachments/assets/df974ef3-c831-443b-ad14-60464951b9ab" />

<img width="518" height="175" alt="image" src="https://github.com/user-attachments/assets/5a3b3172-cb74-415a-ae40-e938583b3d77" />

<img width="677" height="133" alt="image" src="https://github.com/user-attachments/assets/929f7c76-237d-4e91-ab96-53f4c07f8f04" />

<img width="831" height="219" alt="image" src="https://github.com/user-attachments/assets/493cbcda-61ed-4a38-af20-b936c9c6e6ba" />

<img width="831" height="219" alt="image" src="https://github.com/user-attachments/assets/384428f6-656b-43f6-bcb9-f79ababbc6de" />
