### PR TITLE
fix: align VS Code engine and @types/vscode to ^1.110.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
                 "@types/tar": "^7.0.87",
                 "@types/tmp": "^0.2.6",
                 "@types/unzipper": "^0.10.9",
-                "@types/vscode": "^1.120.0",
+                "@types/vscode": "^1.110.0",
                 "@types/websocket": "^1.0.10",
                 "@types/yamljs": "^0.2.34",
                 "@typescript-eslint/eslint-plugin": "^8.58.1",
@@ -78,7 +78,7 @@
                 "webpack-cli": "^7.0.2"
             },
             "engines": {
-                "vscode": "^1.108.1"
+                "vscode": "^1.110.0"
             }
         },
         "node_modules/@azu/format-text": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "version": "1.3.29",
     "publisher": "ms-kubernetes-tools",
     "engines": {
-        "vscode": "^1.108.1"
+        "vscode": "^1.110.0"
     },
     "license": "Apache-2.0",
     "categories": [
@@ -1313,7 +1313,7 @@
         "@types/tar": "^7.0.87",
         "@types/tmp": "^0.2.6",
         "@types/unzipper": "^0.10.9",
-        "@types/vscode": "^1.120.0",
+        "@types/vscode": "^1.110.0",
         "@types/websocket": "^1.0.10",
         "@types/yamljs": "^0.2.34",
         "@typescript-eslint/eslint-plugin": "^8.58.1",


### PR DESCRIPTION
### Title
fix: align VS Code engine and @types/vscode versions to resolve update failure

### Summary

The extension was failing to update for some users due to a mismatch between the declared VS Code engine range and the `@types/vscode` typings version. The typings were pinned to `^1.120.0` while the engine allowed installs on VS Code as old as `1.108.1`, this change makes it more centred approach & aligns with aks extension as well, leading to API surface inconsistencies and update failures.

This PR aligns both values to `^1.110.0`.

### Changes

- package.json
  - `engines.vscode`: `^1.108.1` → `^1.110.0`
  - `devDependencies["@types/vscode"]`: `^1.120.0` → `^1.110.0`
- package-lock.json
  - Regenerated to reflect the version changes above.

### Motivation
- Ensures the typings used at build time match the minimum supported VS Code runtime.
- Prevents the extension update failure observed on supported VS Code versions.
- Establishes a single, consistent baseline (`1.110.0`) for both the engine and typings.

### Risk / Compatibility
- Users on VS Code `< 1.110.0` will no longer receive updates of this extension; they must upgrade VS Code. This is intentional and matches the API surface the extension actually targets.
- No source/runtime code changes — manifest and lockfile only.

### Testing
- `npm install` succeeds with updated lockfile.
- Extension builds (`npm run compile` / `webpack`) without TypeScript errors against `@types/vscode@1.110.x`.
- Extension loads and activates in VS Code `1.110.0`+.

### Checklist
- [x] Engine and typings versions aligned
- [x] package-lock.json regenerated

Gentle FYI: @bosesuneha , @tejhan , @davidgamero + @gambtho, @squillace 