### PR TITLE
docs: add CNCF/LF Projects copyright disclaimer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,3 +353,9 @@ the `vs-helm` extension by @technosophos.
 
 The 'infer `kubectl` version' feature was inspired by @jakepearson's `k` utility
 (https://github.com/jakepearson/k), and some parts of the design were based on his implementation.
+
+---
+
+Copyright Contributors to vscode-kubernetes-tools, established as
+vscode-kubernetes-tools a Series of LF Projects, LLC.
+


### PR DESCRIPTION
### Summary

Adds the required copyright/footer disclaimer to README.md as requested by the CNCF projects team, noting that `vscode-kubernetes-tools` is established as a Series of LF Projects, LLC.

Fixes #1902

### Changes

- README.md: Append a footer section with the CNCF-recommended copyright notice and a link to the LF Projects policies page.

### Motivation

The project has been converted to a Series of LF Projects, LLC, but the repository did not yet carry the visible disclaimer required by the [CNCF website guidelines](https://github.com/cncf/foundation/policies-guidance/website-guidelines.md). This PR brings the repo into compliance.

### Disclaimer text added

> Copyright Contributors to vscode-kubernetes-tools, established as vscode-kubernetes-tools a Series of LF Projects, LLC.


### Risk / Compatibility

Documentation-only change. No code, build, or runtime impact.

### Checklist

- [x] Disclaimer text matches the wording requested in #1902
- [x] Link to LF Projects policies included
- [x] No code changes


❤️ Gentle FYI: @bosesuneha , @tejhan , @davidgamero + @gambtho, @squillace

