### PR TITLE
Bump Vscode engine verson from 1.108.1 to 1.120.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "version": "1.3.29",
     "publisher": "ms-kubernetes-tools",
     "engines": {
-        "vscode": "^1.108.1"
+        "vscode": "^1.120.0"
     },
     "license": "Apache-2.0",
     "categories": [


### PR DESCRIPTION
This PR bumps `vscode` in `engines` from 1.108.1 to 1.120.0. 

This fixes a build issue we have due to `@types/vscode` being a higher version than the engine version,

Verified & tested this new supported version has no immediate breaking changes.