### PR TITLE
Publish release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * fix: align VS Code engine and @types/vscode to ^1.110.0
 * docs: add CNCF/LF Projects copyright disclaimer to README
 * Docs: Fix outdated references across documentation
+* Updating auth prompt detection to match additional known login URLs
 
 Contributors: Thank you so much for Contributions and Reviews from knowlsie, tejhan, bosesuneha, Tatsinnit. Thank you all!!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Change Log
 
+## [1.4.0]
+
+* Dependabot PRs
+* [Test Suite Update]: mergeIntoKubeconfig test suite addition & suite config updates
+* Update: vscode package version and engine
+* Publish security policy documentation
+* Add bug & vulnerability reporting guidelines to CONTRIBUTING.md
+* Pin HaaLeo/publish-vscode-extension
+* Add 1es pipeline for release
+* Updating Python debugger to use ms-python.debugpy & updating extension configuration
+* Update CI workflow triggers from master to main
+* Fix Typescript 6 compilation errors
+* Adding distinguishable icons for spawned terminals
+* Update GitHub release workflow to only create release
+* Update OWNERS.md - maintainer list changes
+* docs(owners): separate emeritus maintainers from current list
+* fix: align VS Code engine and @types/vscode to ^1.110.0
+* docs: add CNCF/LF Projects copyright disclaimer to README
+* Docs: Fix outdated references across documentation
+
+Contributors: Thank you so much for Contributions and Reviews from knowlsie, tejhan, bosesuneha, Tatsinnit. Thank you all!!
+
 ## [1.3.29]
 
 * Dependabot PRs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-kubernetes-tools",
-    "version": "1.3.29",
+    "version": "1.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-kubernetes-tools",
-            "version": "1.3.29",
+            "version": "1.4.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@azure/arm-containerservice": "^25.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-kubernetes-tools",
     "displayName": "Kubernetes",
     "description": "Develop, deploy and debug Kubernetes applications",
-    "version": "1.3.29",
+    "version": "1.4.0",
     "publisher": "ms-kubernetes-tools",
     "engines": {
         "vscode": "^1.110.0"


### PR DESCRIPTION
Hiya All, this PR is for release `1.4.0`.

This release contains following updates:

* Dependabot PRs
* [Test Suite Update]: mergeIntoKubeconfig test suite addition & suite config updates
* Update: vscode package version and engine
* Publish security policy documentation
* Add bug & vulnerability reporting guidelines to CONTRIBUTING.md
* Pin HaaLeo/publish-vscode-extension
* Add 1es pipeline for release
* Updating Python debugger to use ms-python.debugpy & updating extensio…
* Update CI workflow triggers from master to main
* Fix Typescript 6 compilation errors
* Adding distingishuable icons for spawned terminals
* Update GitHub release workflow to only create release
* Update OWNERS.md - maintainer list changes
* docs(owners): separate emeritus maintainers from current list
* fix: align VS Code engine and @types/vscode to ^1.110.0
* docs: add CNCF/LF Projects copyright disclaimer to README
* Docs: Fix outdated references across documentation

**Contributors**: Thank you so much for Contributions and Reviews from @knowlsie, @tejhan, @bosesuneha, @Tatsinnit. Thank you all!!

❤️  Gentle fyi to @tejhan , @knowlsie ,  @bosesuneha, @ashu8912, @davidgamero ,  cc: @squillace , @gambtho, also gentle fyi @krook
 
### Test VSIX: 

* [vscode-kubernetes-tools-1.4.0-test.vsix.zip](https://github.com/user-attachments/files/28202285/vscode-kubernetes-tools-1.4.0-test.vsix.zip)
* Latest VSIX with Tejhan's changes: 
[vscode-kubernetes-tools-1.4.0-pre-release-test.vsix.zip](https://github.com/user-attachments/files/28362604/vscode-kubernetes-tools-1.4.0-pre-release-test.vsix.zip)



Thank you all!!

