### PR TITLE
Updating auth prompt detection to match additional known login URLs

### DIFF
--- a/src/shell.ts
+++ b/src/shell.ts
@@ -175,8 +175,10 @@ function execCore(cmd: string, opts: any, callback?: ((proc: ChildProcess) => vo
     });
 }
 
-// Pattern to detect Azure AD device login prompts
-const AUTH_PROMPT_PATTERN = /microsoft\.com\/devicelogin/i;
+// Pattern to detect Azure AD device login prompts (covers multiple URL variants)
+// Known URLs: microsoft.com/devicelogin, login.microsoft.com/device, login.microsoftonline.com/.../oauth2/deviceauth
+// Requires https:// prefix to avoid matching substrings in unrelated URLs
+const AUTH_PROMPT_PATTERN = /https:\/\/(?:[a-z0-9-]+\.)?microsoft(?:online)?\.com\/(?:device|devicelogin|common\/oauth2\/deviceauth)/i;
 
 let authNotificationShown = false;
 


### PR DESCRIPTION
The authentication prompt detection added in #1795 only matched the `microsoft.com/devicelogin` URL. Newer versions of kubelogin and Azure CLI may use `login.microsoft.com/device` or `login.microsoftonline.com/common/oauth2/deviceauth`, causing the extension to hang indefinitely when Azure authentication is required.

This updates the regex pattern to cover all known device login URL variants:
- `microsoft.com/devicelogin` (legacy)
- `login.microsoft.com/device` (current)
- `login.microsoftonline.com/common/oauth2/deviceauth`

Fixes infinite loading when expanding namespaces or other resources on Azure clusters that require re-authentication.