### PR TITLE
Add resource name filter to the Clusters tree view

### DIFF
--- a/package.json
+++ b/package.json
@@ -452,6 +452,16 @@
                     "group": "navigation"
                 },
                 {
+                    "command": "extension.vsKubernetesFilterExplorer",
+                    "when": "view == extension.vsKubernetesExplorer",
+                    "group": "navigation"
+                },
+                {
+                    "command": "extension.vsKubernetesClearFilterExplorer",
+                    "when": "view == extension.vsKubernetesExplorer && extension.vsKubernetesExplorerFilterActive",
+                    "group": "navigation"
+                },
+                {
                     "command": "extension.vsKubernetesCreateCluster",
                     "when": "view == extension.vsKubernetesExplorer",
                     "group": "0"
@@ -1030,6 +1040,18 @@
                     "light": "images/light/refresh.svg",
                     "dark": "images/dark/refresh.svg"
                 }
+            },
+            {
+                "command": "extension.vsKubernetesFilterExplorer",
+                "title": "Filter Resources by Name",
+                "category": "Kubernetes",
+                "icon": "$(filter)"
+            },
+            {
+                "command": "extension.vsKubernetesClearFilterExplorer",
+                "title": "Clear Resource Filter",
+                "category": "Kubernetes",
+                "icon": "$(clear-all)"
             },
             {
                 "command": "extension.vsKubernetesShowEvents",

--- a/src/components/clusterexplorer/explorer.ts
+++ b/src/components/clusterexplorer/explorer.ts
@@ -89,6 +89,8 @@ export class KubernetesExplorer implements vscode.TreeDataProvider<ClusterExplor
     private readonly customisers = Array.of<ExplorerUICustomizer<ClusterExplorerNode>>();
     private refreshTimer: NodeJS.Timeout | undefined;
     private readonly refreshQueue = Array<ClusterExplorerNode>();
+    private treeView: vscode.TreeView<ClusterExplorerNode> | undefined;
+    private resourceNameFilter: string | undefined;
 
     constructor(private readonly kubectl: Kubectl, private readonly host: Host) {
         host.onDidChangeConfiguration((change) => {
@@ -103,6 +105,7 @@ export class KubernetesExplorer implements vscode.TreeDataProvider<ClusterExplor
             treeDataProvider: this,
             showCollapseAll: true
         });
+        this.treeView = viewer;
         return vscode.Disposable.from(
 			viewer,
             viewer.onDidCollapseElement(this.onElementCollapsed, this),
@@ -134,7 +137,29 @@ export class KubernetesExplorer implements vscode.TreeDataProvider<ClusterExplor
         const contributedChildren = this.extenders
                                         .filter((e) => e.contributesChildren(parent))
                                         .map((e) => e.getChildren(parent));
-        return providerResult.append(baseChildren, ...contributedChildren);
+        const allChildren = providerResult.append(baseChildren, ...contributedChildren);
+        if (!this.resourceNameFilter) {
+            return allChildren;
+        }
+        // Keep the tree structure (folders, contexts, etc.) intact and only filter
+        // resource leaf nodes by name.  Non-resource nodes always pass the predicate.
+        const needle = this.resourceNameFilter.toLowerCase();
+        return providerResult.filter(allChildren, (node) =>
+            node.nodeType !== NODE_TYPES.resource || node.name.toLowerCase().includes(needle));
+    }
+
+    getResourceNameFilter(): string | undefined {
+        return this.resourceNameFilter;
+    }
+
+    setResourceNameFilter(filter: string | undefined): void {
+        const trimmed = filter ? filter.trim() : undefined;
+        this.resourceNameFilter = trimmed && trimmed.length > 0 ? trimmed : undefined;
+        vscode.commands.executeCommand('setContext', 'extension.vsKubernetesExplorerFilterActive', !!this.resourceNameFilter);
+        if (this.treeView) {
+            this.treeView.message = this.resourceNameFilter ? `Filtering resources by: ${this.resourceNameFilter}` : undefined;
+        }
+        this.refresh();
     }
 
     async watch(node: ClusterExplorerNode): Promise<void> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -208,6 +208,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
         registerCommand('extension.vsKubernetesConfigureFromCluster', configureFromClusterKubernetes),
         registerCommand('extension.vsKubernetesCreateCluster', createClusterKubernetes),
         registerCommand('extension.vsKubernetesRefreshExplorer', () => treeProvider.refresh()),
+        registerCommand('extension.vsKubernetesFilterExplorer', async () => {
+            const value = await vscode.window.showInputBox({
+                prompt: 'Filter cluster resources by name',
+                placeHolder: 'Type part of a resource name (empty to clear)',
+                value: treeProvider.getResourceNameFilter()
+            });
+            if (value !== undefined) {  // undefined === user pressed Esc; '' clears
+                treeProvider.setResourceNameFilter(value);
+            }
+        }),
+        registerCommand('extension.vsKubernetesClearFilterExplorer', () => treeProvider.setResourceNameFilter(undefined)),
         registerCommand('extension.vsKubernetesRefreshHelmRepoExplorer', () => helmRepoTreeProvider.refresh()),
         registerCommand('extension.vsKubernetesRefreshCloudExplorer', () => cloudExplorer.refresh()),
         registerCommand('extension.vsKubernetesUseContext', useContextKubernetes),

--- a/src/utils/providerresult.ts
+++ b/src/utils/providerresult.ts
@@ -38,6 +38,16 @@ export function map<T, U>(source: vscode.ProviderResult<T[]>, f: (t: T) => U): U
     return source.map(f);
 }
 
+export function filter<T>(source: vscode.ProviderResult<T[]>, predicate: (t: T) => boolean): vscode.ProviderResult<T[]> {
+    if (isThenable(source)) {
+        return filterThenable(source, predicate);
+    }
+    if (!source) {
+        return source;
+    }
+    return source.filter(predicate);
+}
+
 function isThenable<T>(r: vscode.ProviderResult<T>): r is Thenable<T | null | undefined> {
     return !!((r as Thenable<T>).then);
 }
@@ -76,6 +86,14 @@ async function mapThenable<T, U>(obj: Thenable<T[] | null | undefined>, f: (t: T
         return sequence;
     }
     return sequence.map(f);
+}
+
+async function filterThenable<T>(obj: Thenable<T[] | null | undefined>, predicate: (t: T) => boolean): Promise<T[] | null | undefined> {
+    const sequence = await obj;
+    if (!sequence) {
+        return sequence;
+    }
+    return sequence.filter(predicate);
 }
 
 async function whenReady<T>(w: Thenable<true>, obj: T): Promise<T> {


### PR DESCRIPTION
## Summary

Adds a **name filter** to the **Clusters** tree view so users can quickly narrow long resource lists (Pods, Services, Ingresses, Deployments, …) instead of scrolling.

A **filter** icon in the Clusters view title bar opens an input box; typing matches resource leaf nodes by name (case-insensitive substring). While a filter is active, a **clear** icon appears next to it and the view shows a `Filtering resources by: <text>` header. Folders and the cluster structure stay intact — only the resource *items* inside them are filtered.

## Motivation

Real clusters routinely list dozens or hundreds of resources of a single kind. The Clusters explorer had no way to filter them, so locating a specific pod/ingress/etc. meant scrolling through the whole list.

VS Code's extension API does not allow docking a persistent text input above a native `TreeView`, so this uses the idiomatic pattern — a title-bar button that drives the filter — which keeps all native tree behavior (context menus, watch/refresh, reveal).

## What changed

- **`src/components/clusterexplorer/explorer.ts`** — `KubernetesExplorer` now holds an optional `resourceNameFilter`. The filter is applied in `getChildren()` (the single point all nodes pass through): only nodes with `nodeType === resource` are matched against the needle; folders, contexts, config items, helm and message nodes always pass. New `getResourceNameFilter()` / `setResourceNameFilter()` methods set the filter, toggle a `setContext` key, surface the active filter as the tree view's header message, and refresh.
- **`src/utils/providerresult.ts`** — Added a `filter()` helper that mirrors the existing `map()`, handling the array-or-`Thenable` duality of `ProviderResult<T[]>`.
- **`src/extension.ts`** — Registered two commands: `extension.vsKubernetesFilterExplorer` (opens the input box, pre-filled with the current filter) and `extension.vsKubernetesClearFilterExplorer`.
- **`package.json`** — Declared both commands (codicons `$(filter)` / `$(clear-all)`, no new image assets) and added them to the Clusters `view/title` `navigation` group. The clear button is gated on `extension.vsKubernetesExplorerFilterActive` so it only shows while filtering.

## Behavior notes

- Matching is case-insensitive substring (e.g. `tecno` matches `tecnocasa-portale-dev-0`).
- The filter is provider-wide (applies across all listed contexts) and is re-applied on every refresh, including watch-driven refreshes.
- Submitting an empty input box, or pressing the clear button, removes the filter; pressing Esc leaves it unchanged.

## Testing

- `npm install`
- `tsc -p ./ --noEmit` → no type errors
- `eslint ./src` on the touched files → clean
- Manually in the Extension Development Host: expanded a cluster → Workloads → Pods, used the filter icon to narrow the list, verified folders remained, the header message appeared, and the clear button reset the view. Confirmed non-resource items (e.g. ConfigMap keys, pod status info lines) are unaffected, and that the filter persists across refresh.

## Out of scope (possible follow-ups)

- Per-resource-kind filtering (current design is provider-wide).
- Fuzzy matching (the `fuzzysearch` dependency is available; substring chosen for predictability).
- Auto-hiding empty folders / auto-expanding folders that contain matches (would require eager fetching across folders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
