### PR TITLE
Bump codeql-action/init+analyze to v.4.37.0 and group them for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,7 +67,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -95,6 +95,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Recently, (seemingly as of  `github/codeql-action v.4.36.2`) Dependabot started bumping `codeql-action/init` and `/analyze` in separate PRs.

They must run the same version, so they mismatch and analyze fails: `Loaded a configuration file for version '4.37.0', but running version '4.36.2'`.

This PR updates both simultaneously as well as adds a `groups` config to our `dependabot.yml` so that we bump these dependencies together in the future. 

Changes:

- Bump both `init` and `analyze` to v4.37.0.
- Add a `codeql` group in `dependabot.yml` so future bumps come as one PR.

After merge, we can close both #1966 and #1967. 

These are both failing due to the aforementioned version mismatch.

- https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/pull/1967
- https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/pull/1966