### PR TITLE
config option suppress missing kubeconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,6 +214,11 @@
                             "default": false,
                             "description": "Suppresses the display of warnings if no helm binary is available"
                         },
+                        "vs-kubernetes.suppress-kubeconfig-not-found-alerts": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Suppresses the display of warnings if no kubeconfig file is available"
+                        },
                         "vs-kubernetes.ignore-recommendations": {
                             "type": "boolean",
                             "default": false,

--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -336,6 +336,14 @@ export function setSuppressHelmNotFound(suppress:boolean):void{
     setConfigValue('vs-kubernetes.suppress-helm-not-found-alerts', suppress);
 }
 
+export function suppressKubeconfigNotFound(): boolean {
+    return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.suppress-kubeconfig-not-found-alerts'];
+}
+
+export function setSuppressKubeconfigNotFound(suppress:boolean):void{
+    setConfigValue('vs-kubernetes.suppress-kubeconfig-not-found-alerts', suppress);
+}
+
 export function ignoreK8sRecommendations(): boolean {
     return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.ignore-recommendations'];
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2151,7 +2151,9 @@ async function validateKubeconfigPath() {
             }
         }
 
-        if (!exists) {
+        // suppressKubeconfigNotFound (vs-kubernetes.suppress-kubeconfig-not-found-alerts)
+        // hides this startup "add a new one?" prompt when enabled.
+        if (!exists && !config.suppressKubeconfigNotFound()) {
         const choice = await vscode.window.showWarningMessage(
             `Kubeconfig not found at: ${path}. Add a new one?`,
             'Add',


### PR DESCRIPTION
## Summary

Adds a config option to disable the startup "Kubeconfig not found … Add a new one?" alert that requires acknowledgement.

Some users intentionally reference kubeconfig paths that don't always exist on disk (e.g. transient/generated configs, remote or on-demand setups). For them this startup prompt is noise that must be dismissed repeatedly. This lets them opt out.

## Change

New boolean setting **`vs-kubernetes.suppress-kubeconfig-not-found-alerts`** (default `false`), following the existing `suppress-*-not-found-alerts` pattern (e.g. helm).

- `package.json` — contributes the new configuration option.
- `src/components/config/config.ts` — adds `suppressKubeconfigNotFound()` / `setSuppressKubeconfigNotFound()` accessors.
- `src/extension.ts` — when the setting is enabled, suppresses the startup **"Kubeconfig not found at: … Add a new one?"** prompt in `validateKubeconfigPath()`.

Default behavior is unchanged; the prompt still appears unless a user explicitly enables the setting.

## Notes

- Scoped to feature-only changes — earlier formatting churn and an unrelated dependency `overrides` block were removed so the diff reflects just this feature (3 files, +16/-1).
- All commits are DCO signed-off.
