### PR TITLE
Publish release 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [1.4.1]
+
+* Dependabot PRs
+* Fix repo checkout 1es pipeline.
+* ESLint 10 only supports flat config.
+* ci: replace gulp/tslint with eslint, clean up build workflow, add pre-commit hook.
+* ci: bump codeql-action/init+analyze to v.4.37.0 and group them
+* suppress kubeconfig warning option
+
+Contributors: Thank you so much for Contributions and Reviews from davidgamero, tejhan, bosesuneha, Tatsinnit. Thank you all!!
+
 ## [1.4.0]
 
 * Dependabot PRs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-kubernetes-tools",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-kubernetes-tools",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@azure/arm-containerservice": "^25.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-kubernetes-tools",
     "displayName": "Kubernetes",
     "description": "Develop, deploy and debug Kubernetes applications",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "publisher": "ms-kubernetes-tools",
     "engines": {
         "vscode": "^1.110.0"


### PR DESCRIPTION
Hiya all, this PR is for the release `1.4.1`, release include the following:

## [1.4.1]

* Dependabot PRs
* Fix repo checkout 1es pipeline.
* ESLint 10 only supports flat config.
* ci: replace gulp/tslint with eslint, clean up build workflow, add pre-commit hook.
* ci: bump codeql-action/init+analyze to v.4.37.0 and group them
* suppress kubeconfig warning option

Contributors: Thank you so much for Contributions and Reviews from davidgamero, tejhan, bosesuneha, Tatsinnit.

Gentle fyi ❤️  @davidgamero , @bosesuneha , @tejhan cc: @squillace + @gambtho ❤️ 

Thank you!!

**VSIX to test reside here:** 

-  [vscode-kubernetes-tools-1.4.1-test.vsix.zip](https://github.com/user-attachments/files/30287657/vscode-kubernetes-tools-1.4.1-test.vsix.zip)
