### PR TITLE
ci: pin workflow action SHAs in build-dev and move Node.js to 22

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -22,12 +22,12 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v7.0.1
-    - name: Use node.js
-      uses: actions/setup-node@v6
+    - name: Checkout repository
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - name: Setup Node.js
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: 20
+        node-version: '22'
     - name: Install dependencies
       run: npm install
     - name: Build
@@ -48,7 +48,7 @@ jobs:
         mv *.vsix vsix
     - name: Archive extension
       if: github.event_name == 'push' && matrix.os == 'ubuntu-latest'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: vsix
         path: vsix


### PR DESCRIPTION
## Summary

This change hardens the build-dev workflow by pinning GitHub Actions to specific commit SHAs and updates the Node runtime to 22 for CI builds. Also, take cares of this PR: https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/pull/1975 

## What changed

- Pinned:
  - `actions/checkout` to a specific SHA (v7.0.0)
  - `actions/setup-node` to a specific SHA (v6.4.0)
  - `actions/upload-artifact` to a specific SHA (v7.0.1)
- Renamed workflow step labels for readability:
  - `Checkout` -> `Checkout repository`
  - `Use node.js` -> `Setup Node.js`
- Updated `node-version` from `20` to `'22'`

## Why

- Improves supply-chain security and reproducibility by avoiding floating action tags.
- Aligns CI with the intended Node.js version for current development and dependency compatibility.
- Keeps workflow logs clearer with explicit step names.

## Validation

- Workflow YAML updated cleanly with no functional changes to build/test/package flow beyond the Node version bump.
- Artifact upload behavior remains unchanged.