### PR TITLE
fix: align engines.vscode with @types/vscode (^1.125.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "version": "1.4.1",
     "publisher": "ms-kubernetes-tools",
     "engines": {
-        "vscode": "^1.110.0"
+        "vscode": "^1.125.0"
     },
     "license": "Apache-2.0",
     "categories": [


### PR DESCRIPTION
## Problem

The build/packaging step breaks due to a version mismatch introduced in #1957:

- `@types/vscode`: `^1.125.0` (bumped in #1957)
- `engines.vscode`: `^1.110.0` (unchanged)

`vsce package` fails when `@types/vscode` is newer than `engines.vscode`, because the extension would be typed against VS Code APIs newer than the minimum version it declares support for.

## Fix

Raise `engines.vscode` to `^1.125.0` so it matches the already-updated `@types/vscode`. This is a minimal, single-line change with no lockfile impact.

## Verification

- `vsce ls` no longer aborts with the `@types/vscode greater than engines.vscode` error.