### PR TITLE
fix: do not block activation on the kubeconfig-not-found prompt (#1999)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -135,7 +135,6 @@ export const HELM_TPL_MODE: vscode.DocumentFilter = { language: "helm", scheme: 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export async function activate(context: vscode.ExtensionContext): Promise<APIBroker> {
-    await validateKubeconfigPath();
     setAssetContext(context);
 
     await fixOldInstalledBinaryPermissions(shell);
@@ -387,6 +386,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
     vscode.workspace.registerTextDocumentContentProvider(configmaps.uriScheme, configMapProvider);
 
     recommendExtensions(kubectl, context);
+
+    // The kubeconfig check can prompt the user, and a VS Code notification with buttons only
+    // resolves once the user responds to (or dismisses) it. Awaiting that during activation
+    // leaves activate() pending forever, so no commands - including
+    // extension.vsKubernetesRefreshExplorer - ever get registered. Kick it off in the
+    // background instead, and never let it fail activation. See issue #1999.
+    validateKubeconfigPath().catch((err) => {
+        console.warn(`Error validating kubeconfig path: ${err}`);
+    });
 
     return apiBroker(clusterProviderRegistry, kubectl, portForwardStatusBarManager, treeProvider, cloudExplorer, localTunnelDebugger, onDidChangeKubeconfigEmitter, activeContextTracker, kubectlUtils.onDidChangeNamespaceEmitter);
 }
@@ -2182,15 +2190,15 @@ async function validateKubeconfigPath() {
         // suppressKubeconfigNotFound (vs-kubernetes.suppress-kubeconfig-not-found-alerts)
         // hides this startup "add a new one?" prompt when enabled.
         if (!exists && !config.suppressKubeconfigNotFound()) {
-        const choice = await vscode.window.showWarningMessage(
-            `Kubeconfig not found at: ${path}. Add a new one?`,
-            'Add',
-            'Cancel'
-        );
-        if (choice === 'Add') {
-            await useKubeconfigKubernetes();
-        }
-        break;
+            const choice = await vscode.window.showWarningMessage(
+                `Kubeconfig not found at: ${path}. Add a new one?`,
+                'Add',
+                'Cancel'
+            );
+            if (choice === 'Add') {
+                await useKubeconfigKubernetes();
+            }
+            break;
         }
     }
 }

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 
-import { runTests } from "@vscode/test-electron";
+import { downloadAndUnzipVSCode, runTests, runVSCodeCommand } from "@vscode/test-electron";
 
 
 async function main() {
@@ -13,8 +13,19 @@ async function main() {
 		// Passed to --extensionTestsPath
 		const extensionTestsPath = path.resolve(__dirname, './suite/index');
 
-		// Download VS Code, unzip it and run the integration test
-		await runTests({ extensionDevelopmentPath, extensionTestsPath, version: "stable" });
+		// Allow pinning the VS Code version under test, e.g. VSCODE_TEST_VERSION=1.132.0.
+		const version = process.env['VSCODE_TEST_VERSION'] || "stable";
+
+		// Download VS Code and unzip it.
+		const vscodeExecutablePath = await downloadAndUnzipVSCode(version);
+
+		// Our `extensionDependencies` have to be present in the test instance, otherwise VS Code
+		// refuses to activate us at all ("Cannot activate the 'Kubernetes' extension because it
+		// depends on unknown extension 'redhat.vscode-yaml'").
+		await runVSCodeCommand(['--install-extension', 'redhat.vscode-yaml', '--force'], { version });
+
+		// Run the integration tests.
+		await runTests({ vscodeExecutablePath, extensionDevelopmentPath, extensionTestsPath });
 	} catch (err) {
 		console.error(`Failed to run tests ${err}`);
 		process.exit(1);

--- a/test/suite/activation.test.ts
+++ b/test/suite/activation.test.ts
@@ -1,0 +1,66 @@
+import * as assert from 'assert';
+import * as os from 'os';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+
+const EXTENSION_ID = 'ms-kubernetes-tools.vscode-kubernetes-tools';
+const REFRESH_EXPLORER_COMMAND = 'extension.vsKubernetesRefreshExplorer';
+
+// Regression test for https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/issues/1999
+//
+// activate() used to `await validateKubeconfigPath()` before registering any commands. That
+// function shows a "Kubeconfig not found... Add a new one?" notification, and a VS Code
+// notification with buttons only resolves once the user answers or dismisses it. If the user
+// ignored the notification, activate() stayed pending forever and none of the extension's
+// commands were ever registered, so every invocation failed with
+// "command 'extension.vsKubernetesRefreshExplorer' not found".
+suite("Extension activation", () => {
+    let sandbox: sinon.SinonSandbox;
+    let originalKubeconfig: string | undefined;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        originalKubeconfig = process.env['KUBECONFIG'];
+
+        // Simulate a user who never answers the notification.
+        sandbox.stub(vscode.window, 'showWarningMessage').returns(new Promise(() => { /* never settles */ }) as any);
+
+        // Point at a kubeconfig that cannot exist, so the notification is triggered.
+        process.env['KUBECONFIG'] = path.join(os.tmpdir(), 'vscode-kubernetes-tools-no-such-dir', 'config');
+    });
+
+    teardown(() => {
+        sandbox.restore();
+        if (originalKubeconfig === undefined) {
+            delete process.env['KUBECONFIG'];
+        } else {
+            process.env['KUBECONFIG'] = originalKubeconfig;
+        }
+    });
+
+    test("completes and registers commands even if the kubeconfig prompt is never answered", async function () {
+        this.timeout(60000);
+
+        const extension = vscode.extensions.getExtension(EXTENSION_ID);
+        assert.ok(extension, `extension ${EXTENSION_ID} not found`);
+
+        const TIMED_OUT = Symbol('timed out');
+        let timer: NodeJS.Timeout | undefined;
+        const timeout = new Promise<symbol>((resolve) => {
+            timer = setTimeout(() => resolve(TIMED_OUT), 30000);
+        });
+
+        try {
+            const outcome = await Promise.race([extension.activate(), timeout]);
+            assert.notStrictEqual(outcome, TIMED_OUT, 'activate() did not complete - it is blocked on a user prompt');
+        } finally {
+            if (timer) {
+                clearTimeout(timer);
+            }
+        }
+
+        const commands = await vscode.commands.getCommands(true);
+        assert.ok(commands.includes(REFRESH_EXPLORER_COMMAND), `${REFRESH_EXPLORER_COMMAND} was not registered`);
+    });
+});

--- a/test/suite/components/kubectl/kubeconfig-merge.test.ts
+++ b/test/suite/components/kubectl/kubeconfig-merge.test.ts
@@ -28,7 +28,7 @@ suite("Kubeconfig Merge", () => {
     let sandbox: sinon.SinonSandbox;
     let tempDir: string;
     let originalKubeconfig: string | undefined;
-    let refreshExplorerDisposable: vscode.Disposable;
+    let refreshExplorerDisposable: vscode.Disposable | undefined;
 
     // Helper to create a temp kubeconfig file & set the corresponding env var
     function setupKubeconfig(content: string): string {
@@ -73,16 +73,21 @@ suite("Kubeconfig Merge", () => {
         });
     }
 
-    setup(() => {
+    setup(async () => {
         sandbox = sinon.createSandbox();
         tempDir = fsNode.mkdtempSync(path.join(os.tmpdir(), 'kubeconfig-test-'));
         originalKubeconfig = process.env['KUBECONFIG'];
 
-        // Register dummy refresh command to prevent invocation for tests
-        refreshExplorerDisposable = vscode.commands.registerCommand(
-            'extension.vsKubernetesRefreshExplorer',
-            () => { /* no-op for tests */ }
-        );
+        // Register dummy refresh command to prevent invocation for tests. If the extension itself
+        // has already been activated it will have registered the real command, in which case we
+        // leave it alone - registering it twice throws.
+        const existingCommands = await vscode.commands.getCommands(true);
+        if (!existingCommands.includes('extension.vsKubernetesRefreshExplorer')) {
+            refreshExplorerDisposable = vscode.commands.registerCommand(
+                'extension.vsKubernetesRefreshExplorer',
+                () => { /* no-op for tests */ }
+            );
+        }
 
         // Stub UI functions to prevent popups / blocks
         sandbox.stub(vscode.window, 'showInformationMessage').resolves(undefined);
@@ -91,7 +96,8 @@ suite("Kubeconfig Merge", () => {
 
     teardown(() => {
         sandbox.restore();
-        refreshExplorerDisposable.dispose();
+        refreshExplorerDisposable?.dispose();
+        refreshExplorerDisposable = undefined;
         // Restore original KUBECONFIG
         if (originalKubeconfig) {
             process.env['KUBECONFIG'] = originalKubeconfig;


### PR DESCRIPTION
Fixes #1999

## Summary

On VS Code **1.132.0** the extension never finishes activating, so none of its commands exist. Every action fails with:

> `command 'extension.vsKubernetesRefreshExplorer' not found. This is likely caused by the extension that contributes extension.vsKubernetesRefreshExplorer.`

Refreshing does not help, because the command is never registered in the first place. Downgrading VS Code to 1.131.0 hides the problem.

Note the versions in the issue title are **VS Code** versions, not extension versions.

## Root cause

`activate()` began with:

```ts
export async function activate(context: vscode.ExtensionContext): Promise<APIBroker> {
    await validateKubeconfigPath();
    ...
```

`validateKubeconfigPath()` shows a notification when the kubeconfig is missing:

```ts
const choice = await vscode.window.showWarningMessage(
    `Kubeconfig not found at: ${path}. Add a new one?`,
    'Add',
    'Cancel'
);
```

A VS Code notification with buttons only settles once the user clicks one or dismisses it. If the user ignores it, that `await` never returns, `activate()` stays pending forever, and the ~120 `registerCommand` calls further down the function (plus the tree data providers, file system providers and status bar items) never run.

`vs-kubernetes.suppress-kubeconfig-not-found-alerts`, added in 1.4.1, lets a user opt out of the prompt, but it does not fix the ordering — anyone who hits the prompt still gets a dead extension.

`getKubeconfigPath()` can also throw (for example when the WSL shell-out fails), and that was likewise unguarded on the activation path.

## Reproduction

Same extension code, same conditions, only the VS Code version differs:

| VS Code | `activate()` | `extension.vsKubernetesRefreshExplorer` registered |
| --- | --- | --- |
| 1.131.0 | completes in ~6s | yes |
| 1.132.0 | never resolves (30s timeout) | no |

## Fix

Move the kubeconfig check off the activation critical path: run it after everything has been registered, do not await it, and swallow its errors so it can never fail activation.

```ts
    recommendExtensions(kubectl, context);

    // The kubeconfig check can prompt the user, and a VS Code notification with buttons only
    // resolves once the user responds to (or dismisses) it. ...
    validateKubeconfigPath().catch((err) => {
        console.warn(`Error validating kubeconfig path: ${err}`);
    });
```

The user-facing behaviour is unchanged — the prompt still appears, and choosing **Add** still opens the kubeconfig picker. It just no longer holds activation hostage.

Also fixes the indentation inside that `if` block, which was misleading.

## Tests

New regression test `test/suite/activation.test.ts` stubs `showWarningMessage` so it never settles (a user who ignores the notification), points `KUBECONFIG` at a missing file, and asserts that `activate()` completes and the refresh command is registered.

Reverting the source fix makes it fail with:

```
AssertionError [ERR_ASSERTION]: activate() did not complete - it is blocked on a user prompt
```

Two supporting changes were needed to make activation testable at all:

* `test/runTest.ts` installs `redhat.vscode-yaml` into the test instance. It is declared in `extensionDependencies`, and without it VS Code refuses to activate the extension: `Cannot activate the 'Kubernetes' extension because it depends on unknown extension 'redhat.vscode-yaml'`. No existing test activated the extension, so this had gone unnoticed.
* `test/runTest.ts` honours `VSCODE_TEST_VERSION` so a specific VS Code build can be pinned, e.g. `VSCODE_TEST_VERSION=1.132.0 npm test`. Defaults to `stable`, so CI is unaffected.
* `kubeconfig-merge.test.ts` only registers its stand-in refresh command when the real extension has not already registered it — registering the same command twice throws.

## Verification

* `VSCODE_TEST_VERSION=1.132.0 npm test` — 59 passing
* `VSCODE_TEST_VERSION=1.131.0 npm test` — 59 passing
* `npm run compile` and `npm run lint` clean
