### PR TITLE
fix: honour the consideration filter when linting

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,6 +69,7 @@ import { setActiveKubeconfig, getKnownKubeconfigs, addKnownKubeconfig } from './
 import { HelmDocumentSymbolProvider } from './helm.symbolProvider';
 import { HelmBlockMatchingProvider } from './helm.blockMatchingProvider';
 import { findParentYaml } from './yaml-support/yaml-navigation';
+import { shouldSkip } from './yaml-support/consideration-filter';
 import { linters } from './components/lint/linters';
 import { timestampText } from './utils/naming';
 import { ContainerContainer } from './utils/containercontainer';
@@ -364,6 +365,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
     vscode.workspace.onDidChangeTextDocument((e) => kubernetesLint(e.document));  // TODO: we could use the change hint
     vscode.workspace.onDidSaveTextDocument(kubernetesLint);
     vscode.workspace.onDidCloseTextDocument((d) => kubernetesDiagnostics.delete(d.uri));
+    // Without this, changing disable-lint or disable-linters has no visible effect until the
+    // document is edited or the window is reloaded.
+    vscode.workspace.onDidChangeConfiguration((e) => {
+        if (e.affectsConfiguration('vs-kubernetes')) {
+            vscode.workspace.textDocuments.forEach(kubernetesLint);
+        }
+    });
     vscode.workspace.textDocuments.forEach(kubernetesLint);
 
     subscriptions.forEach((element) => {
@@ -2326,10 +2334,19 @@ function linterDisabled(disabledLinters: string[], name: string): boolean {
 
 async function kubernetesLint(document: vscode.TextDocument): Promise<void> {
     if (config.getDisableLint()) {
+        // Clear any diagnostics we published before linting was turned off, otherwise they
+        // stay on screen and it looks as if the setting had no effect.
+        kubernetesDiagnostics.delete(document.uri);
         return;
     }
     // Is it a Kubernetes document?
     if (!isLintable(document)) {
+        return;
+    }
+    // Respect the same opt-out that governs schema support: if we don't consider this
+    // document to be ours for schema purposes, we shouldn't be linting it either.
+    if (shouldSkip(document)) {
+        kubernetesDiagnostics.delete(document.uri);
         return;
     }
     const disabledLinters = config.getDisabledLinters();

--- a/test/suite/yaml-consideration-filter.test.ts
+++ b/test/suite/yaml-consideration-filter.test.ts
@@ -39,6 +39,30 @@ suite("YAML consideration-filter", () => {
         });
 
     });
+
+    suite("shouldSkip method", () => {
+
+        test("...defaults to false", async () => {
+            const document = await createYamlDocument('kind: Deployment\n');
+            assert.strictEqual(false, cf.shouldSkip(document));
+        });
+
+        test("...is true if exclude is set", async () => {
+            const document = await createYamlDocument('# vscode-kubernetes-tools: exclude\nkind: Deployment\n');
+            assert.strictEqual(true, cf.shouldSkip(document));
+        });
+
+        test("...is false if include is set", async () => {
+            const document = await createYamlDocument('# vscode-kubernetes-tools: include\nkind: Deployment\n');
+            assert.strictEqual(false, cf.shouldSkip(document));
+        });
+
+        test("...is the inverse of shouldProvideSchemaFor", async () => {
+            const document = await createYamlDocument('# vscode-kubernetes-tools: exclude\nkind: Deployment\n');
+            assert.strictEqual(!cf.shouldProvideSchemaFor(document), cf.shouldSkip(document));
+        });
+
+    });
 });
 
 async function createYamlDocument(text: string): Promise<vscode.TextDocument> {


### PR DESCRIPTION
## What

`kubernetesLint` now consults the consideration filter, so the
`# vscode-kubernetes-tools: exclude` annotation suppresses linting the same way it
already suppresses schema support.

## Why

`shouldProvideSchemaFor` / `shouldSkip` in `src/yaml-support/consideration-filter.ts` is
the extension's answer to "is this document ours?". `requestYamlSchemaUriCallback` honours
it; the linter never has. So a document can be excluded from schema support and still be
linted, which is surprising and, as far as I can tell, unintentional.

The case that led me here is Kustomize patch files. They are deliberately partial
resources, so `resource-limits` flags every container in them:

```yaml
# overlays/local/patch-deployment.yaml -- merged with a base that is complete
apiVersion: apps/v1
kind: Deployment
metadata:
  name: my-server
spec:
  replicas: 2
  template:
    spec:
      containers:
        - name: server
          resources:
            requests:
              cpu: "500m"
              memory: "768Mi"
```
