### PR TITLE
feat: don't treat Kustomize patch files as complete resources

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,6 +69,7 @@ import { setActiveKubeconfig, getKnownKubeconfigs, addKnownKubeconfig } from './
 import { HelmDocumentSymbolProvider } from './helm.symbolProvider';
 import { HelmBlockMatchingProvider } from './helm.blockMatchingProvider';
 import { findParentYaml } from './yaml-support/yaml-navigation';
+import * as kustomizePatchIndex from './yaml-support/kustomize-patch-index';
 import { linters } from './components/lint/linters';
 import { timestampText } from './utils/naming';
 import { ContainerContainer } from './utils/containercontainer';
@@ -381,6 +382,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
     });
     const currentNS = await kubectlUtils.currentNamespace(kubectl);
     updateStatusBarItem(activeNamespaceStatusBarItem, currentNS, 'Current active namespace', !config.isNamespaceStatusBarDisabled());
+
+    kustomizePatchIndex.initialise(context);
+    kustomizePatchIndex.onDidChange(() => updateYAMLSchema(), undefined, context.subscriptions);
 
     await registerYamlSchemaSupport(activeContextTracker, kubectl);
 

--- a/src/yaml-support/consideration-filter.ts
+++ b/src/yaml-support/consideration-filter.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode';
 
+import { isKustomizePatch } from './kustomize-patch-index';
+
 export function shouldProvideSchemaFor(document: vscode.TextDocument): boolean {
     const overrideAnnotationText = findOverrideAnnotation(document);
     if (overrideAnnotationText) {
@@ -23,10 +25,16 @@ interface OverrideAnnotation {
     readonly include?: boolean;
 }
 
-function inferShouldProvideSchemaFor(_document: vscode.TextDocument): boolean {
-    // In future we may want to be smarter, e.g. detecting things which look like Kustomize
-    // patch files.  For now, though, just assume that if it's matched our global document
-    // selector (and doesn't have any override comments) then it's in.
+function inferShouldProvideSchemaFor(document: vscode.TextDocument): boolean {
+    // Kustomize patch files are partial resources, so validating them as complete objects
+    // reports problems with a file that is correct. A patch isn't recognisable on its own -
+    // what identifies it is that a kustomization.yaml names it - so we go by the index of
+    // what the workspace's kustomizations point at. See kustomize-patch-index.ts.
+    if (isKustomizePatch(document.uri)) {
+        return false;
+    }
+    // Otherwise assume that if it matched our global document selector (and doesn't have
+    // any override comments) then it's in.
     return true;
 }
 

--- a/src/yaml-support/kustomize-patch-index.ts
+++ b/src/yaml-support/kustomize-patch-index.ts
@@ -22,13 +22,22 @@ const KUSTOMIZATION_GLOB = '**/[kK]ustomization.{yaml,yml}';
 // kustomization only re-indexes that file.
 const patchesByKustomization = new Map<string, readonly string[]>();
 
+// Reads are asynchronous and can overlap, so a slow read of an earlier revision could
+// otherwise finish last and republish stale paths. Every attempt to change what we know
+// about a kustomization takes a new token; only the newest token may write.
+const generations = new Map<string, number>();
+
+let rescanGeneration = 0;
+
 let allPatchPaths = new Set<string>();
+
+let published = false;
 
 const onDidChangeEmitter = new vscode.EventEmitter<void>();
 
-// Fires when the set of known patch files changes - on the initial scan and whenever a
-// kustomization is created, edited or deleted. Consumers should re-evaluate any documents
-// they have already processed.
+// Fires when the initial scan completes, and thereafter whenever the set of known patch
+// files actually changes. Editing a kustomization without altering the files it names as
+// patches does not fire. Consumers should re-evaluate any documents already processed.
 export const onDidChange = onDidChangeEmitter.event;
 
 export function isKustomizePatch(uri: vscode.Uri): boolean {
@@ -45,7 +54,10 @@ export function initialise(context: vscode.ExtensionContext): void {
     watcher.onDidCreate(reindexOne, undefined, context.subscriptions);
     watcher.onDidChange(reindexOne, undefined, context.subscriptions);
     watcher.onDidDelete((uri) => {
-        patchesByKustomization.delete(normalisePath(uri.fsPath));
+        const key = normalisePath(uri.fsPath);
+        // Take a token as well, so that a read still in flight can't resurrect the entry.
+        generations.set(key, nextGeneration(key));
+        patchesByKustomization.delete(key);
         republish();
     }, undefined, context.subscriptions);
 
@@ -58,8 +70,22 @@ export function initialise(context: vscode.ExtensionContext): void {
 }
 
 async function rescan(): Promise<void> {
+    const generation = ++rescanGeneration;
     const kustomizations = await vscode.workspace.findFiles(KUSTOMIZATION_GLOB);
-    patchesByKustomization.clear();
+    if (generation !== rescanGeneration) {
+        return;  // another rescan started while we were walking the workspace
+    }
+
+    // Prune what has gone rather than clearing outright: clearing would leave the index
+    // empty for the duration of the scan, briefly un-excluding files that are still
+    // patches.
+    const found = new Set(kustomizations.map((uri) => normalisePath(uri.fsPath)));
+    for (const key of Array.from(patchesByKustomization.keys())) {
+        if (!found.has(key)) {
+            patchesByKustomization.delete(key);
+        }
+    }
+
     await Promise.all(kustomizations.map(indexKustomization));
     republish();
 }
@@ -71,15 +97,27 @@ async function reindexOne(uri: vscode.Uri): Promise<void> {
 
 async function indexKustomization(uri: vscode.Uri): Promise<void> {
     const key = normalisePath(uri.fsPath);
+    const generation = nextGeneration(key);
+    generations.set(key, generation);
     try {
         const bytes = await vscode.workspace.fs.readFile(uri);
         const parsed = yaml.load(Buffer.from(bytes).toString('utf8'));
+        if (generations.get(key) !== generation) {
+            return;  // superseded while we were reading
+        }
         patchesByKustomization.set(key, patchFilePaths(parsed, path.dirname(uri.fsPath)));
     } catch {
         // Unreadable or mid-edit and not yet valid YAML. Drop what we knew rather than
         // keeping a stale answer: over-reporting warnings is better than hiding them.
+        if (generations.get(key) !== generation) {
+            return;
+        }
         patchesByKustomization.delete(key);
     }
+}
+
+function nextGeneration(key: string): number {
+    return (generations.get(key) ?? 0) + 1;
 }
 
 function republish(): void {
@@ -89,8 +127,29 @@ function republish(): void {
             combined.add(p);
         }
     }
+
+    // Editing a kustomization usually leaves the patch paths alone, and every event costs
+    // consumers a schema invalidation, so say nothing when nothing changed. The first
+    // publish always fires: consumers need to know the initial scan has landed.
+    if (published && sameContents(allPatchPaths, combined)) {
+        return;
+    }
+
+    published = true;
     allPatchPaths = combined;
     onDidChangeEmitter.fire();
+}
+
+function sameContents(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean {
+    if (left.size !== right.size) {
+        return false;
+    }
+    for (const item of left) {
+        if (!right.has(item)) {
+            return false;
+        }
+    }
+    return true;
 }
 
 // Extracts the files a kustomization declares as patches, resolved against the directory

--- a/src/yaml-support/kustomize-patch-index.ts
+++ b/src/yaml-support/kustomize-patch-index.ts
@@ -1,0 +1,161 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import * as yaml from 'js-yaml';
+
+// Kustomize patch files are partial resources by design: they carry only the fields to be
+// merged over a base, so they legitimately lack properties the schema requires and
+// resources the linters expect. Treating them as complete Kubernetes objects produces
+// warnings about a file that is correct.
+//
+// We can't tell that from the file itself - a patch looks like a truncated resource, and
+// so does a resource someone is halfway through writing. What does distinguish them is
+// that a kustomization.yaml names the patch. So we index what the kustomizations in the
+// workspace point at, and let the consideration filter exclude those files.
+//
+// The lookup must be synchronous: vscode-yaml's schema contributor API is synchronous, and
+// linting runs on every keystroke. Hence an index maintained in the background rather than
+// reading kustomization.yaml on demand.
+
+const KUSTOMIZATION_GLOB = '**/[kK]ustomization.{yaml,yml}';
+
+// Patch paths keyed by the kustomization that declared them, so that editing one
+// kustomization only re-indexes that file.
+const patchesByKustomization = new Map<string, readonly string[]>();
+
+let allPatchPaths = new Set<string>();
+
+const onDidChangeEmitter = new vscode.EventEmitter<void>();
+
+// Fires when the set of known patch files changes - on the initial scan and whenever a
+// kustomization is created, edited or deleted. Consumers should re-evaluate any documents
+// they have already processed.
+export const onDidChange = onDidChangeEmitter.event;
+
+export function isKustomizePatch(uri: vscode.Uri): boolean {
+    if (uri.scheme !== 'file') {
+        return false;
+    }
+    return allPatchPaths.has(normalisePath(uri.fsPath));
+}
+
+export function initialise(context: vscode.ExtensionContext): void {
+    const watcher = vscode.workspace.createFileSystemWatcher(KUSTOMIZATION_GLOB);
+    context.subscriptions.push(watcher, onDidChangeEmitter);
+
+    watcher.onDidCreate(reindexOne, undefined, context.subscriptions);
+    watcher.onDidChange(reindexOne, undefined, context.subscriptions);
+    watcher.onDidDelete((uri) => {
+        patchesByKustomization.delete(normalisePath(uri.fsPath));
+        republish();
+    }, undefined, context.subscriptions);
+
+    vscode.workspace.onDidChangeWorkspaceFolders(() => { rescan(); }, undefined, context.subscriptions);
+
+    // Deliberately not awaited: activation shouldn't block on walking the workspace. Until
+    // the scan lands nothing is excluded, and the onDidChange event tells consumers to
+    // reconsider once it does.
+    rescan();
+}
+
+async function rescan(): Promise<void> {
+    const kustomizations = await vscode.workspace.findFiles(KUSTOMIZATION_GLOB);
+    patchesByKustomization.clear();
+    await Promise.all(kustomizations.map(indexKustomization));
+    republish();
+}
+
+async function reindexOne(uri: vscode.Uri): Promise<void> {
+    await indexKustomization(uri);
+    republish();
+}
+
+async function indexKustomization(uri: vscode.Uri): Promise<void> {
+    const key = normalisePath(uri.fsPath);
+    try {
+        const bytes = await vscode.workspace.fs.readFile(uri);
+        const parsed = yaml.load(Buffer.from(bytes).toString('utf8'));
+        patchesByKustomization.set(key, patchFilePaths(parsed, path.dirname(uri.fsPath)));
+    } catch {
+        // Unreadable or mid-edit and not yet valid YAML. Drop what we knew rather than
+        // keeping a stale answer: over-reporting warnings is better than hiding them.
+        patchesByKustomization.delete(key);
+    }
+}
+
+function republish(): void {
+    const combined = new Set<string>();
+    for (const paths of patchesByKustomization.values()) {
+        for (const p of paths) {
+            combined.add(p);
+        }
+    }
+    allPatchPaths = combined;
+    onDidChangeEmitter.fire();
+}
+
+// Extracts the files a kustomization declares as patches, resolved against the directory
+// containing it. Exported for testing.
+//
+// Only patch fields are considered. Entries under `resources` are complete objects and
+// must keep their schema and lint support.
+export function patchFilePaths(kustomization: unknown, containingDirectory: string): readonly string[] {
+    if (!kustomization || typeof kustomization !== 'object') {
+        return [];
+    }
+
+    const k = kustomization as Record<string, unknown>;
+    const paths: string[] = [];
+
+    const addFile = (entry: unknown) => {
+        if (typeof entry !== 'string' || entry.length === 0) {
+            return;
+        }
+        if (isInlinePatch(entry) || isRemoteReference(entry)) {
+            return;
+        }
+        paths.push(normalisePath(path.resolve(containingDirectory, entry)));
+    };
+
+    // patches: entries are { path } for a file or { patch } for an inline patch.
+    for (const entry of asArray(k.patches)) {
+        if (entry && typeof entry === 'object') {
+            addFile((entry as Record<string, unknown>).path);
+        }
+    }
+
+    // patchesJson6902: deprecated, same { path } shape.
+    for (const entry of asArray(k.patchesJson6902)) {
+        if (entry && typeof entry === 'object') {
+            addFile((entry as Record<string, unknown>).path);
+        }
+    }
+
+    // patchesStrategicMerge: deprecated, entries are either a file path or inline YAML.
+    for (const entry of asArray(k.patchesStrategicMerge)) {
+        addFile(entry);
+    }
+
+    return paths;
+}
+
+function asArray(value: unknown): readonly unknown[] {
+    return Array.isArray(value) ? value : [];
+}
+
+// `patchesStrategicMerge` allows the patch body to be written inline instead of being
+// pointed at. A file path never spans lines, so a newline is a reliable tell.
+function isInlinePatch(entry: string): boolean {
+    return entry.includes('\n');
+}
+
+// Kustomize accepts remote references in several forms. None of them name a local file.
+function isRemoteReference(entry: string): boolean {
+    return /^(https?:\/\/|git@|[a-z][a-z0-9+.-]*::)/i.test(entry) || entry.startsWith('github.com/');
+}
+
+// Windows paths reach us with inconsistent drive-letter casing, so compare
+// case-insensitively there. Elsewhere paths are compared exactly: a case mismatch would
+// break kustomize itself on a case-sensitive filesystem, so it isn't ours to paper over.
+function normalisePath(fsPath: string): string {
+    return process.platform === 'win32' ? fsPath.toLowerCase() : fsPath;
+}

--- a/test/fixtures/kustomize/deployment.yaml
+++ b/test/fixtures/kustomize/deployment.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: server
+spec:
+  selector:
+    matchLabels:
+      app: server
+  template:
+    metadata:
+      labels:
+        app: server
+    spec:
+      containers:
+        - name: server
+          image: example/server:1

--- a/test/fixtures/kustomize/kustomization.yaml
+++ b/test/fixtures/kustomize/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+  - deployment.yaml
+
+patches:
+  - path: patch-deployment.yaml
+    target:
+      kind: Deployment

--- a/test/fixtures/kustomize/patch-deployment.yaml
+++ b/test/fixtures/kustomize/patch-deployment.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: server
+spec:
+  replicas: 2

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -13,8 +13,12 @@ async function main() {
 		// Passed to --extensionTestsPath
 		const extensionTestsPath = path.resolve(__dirname, './suite/index');
 
+		// Opened as the workspace so that tests which need vscode.workspace.findFiles have
+		// something to find. Tests that work on untitled documents are unaffected.
+		const fixtureWorkspacePath = path.resolve(__dirname, '../../test/fixtures/kustomize');
+
 		// Download VS Code, unzip it and run the integration test
-		await runTests({ extensionDevelopmentPath, extensionTestsPath, version: "stable" });
+		await runTests({ extensionDevelopmentPath, extensionTestsPath, version: "stable", launchArgs: [fixtureWorkspacePath] });
 	} catch (err) {
 		console.error(`Failed to run tests ${err}`);
 		process.exit(1);

--- a/test/suite/kustomize-patch-index-workspace.test.ts
+++ b/test/suite/kustomize-patch-index-workspace.test.ts
@@ -1,0 +1,53 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+import * as index from '../../src/yaml-support/kustomize-patch-index';
+
+// Exercises the index against the fixture workspace opened by runTest.ts, rather than the
+// path parsing covered in kustomize-patch-index.test.ts. The module is driven directly:
+// tests run against the TypeScript sources in out/, whereas activating the extension would
+// load the webpack bundle in dist/, which is not rebuilt as part of `npm test`.
+
+suite("Kustomize patch index against a workspace", () => {
+
+    suiteSetup(async function () {
+        this.timeout(20000);
+        const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+        const indexed = new Promise<void>((resolve) => {
+            const subscription = index.onDidChange(() => {
+                subscription.dispose();
+                resolve();
+            });
+        });
+        index.initialise(context);
+        await indexed;
+    });
+
+    test("...recognises a file the kustomization names as a patch", () => {
+        assert.strictEqual(true, index.isKustomizePatch(fixtureUri('patch-deployment.yaml')));
+    });
+
+    test("...does not recognise a file listed under resources", () => {
+        assert.strictEqual(false, index.isKustomizePatch(fixtureUri('deployment.yaml')));
+    });
+
+    test("...does not recognise the kustomization itself", () => {
+        assert.strictEqual(false, index.isKustomizePatch(fixtureUri('kustomization.yaml')));
+    });
+
+    test("...does not recognise a file nothing points at", () => {
+        assert.strictEqual(false, index.isKustomizePatch(fixtureUri('not-mentioned-anywhere.yaml')));
+    });
+
+    test("...does not recognise documents that aren't files", () => {
+        assert.strictEqual(false, index.isKustomizePatch(vscode.Uri.parse('untitled:whatever.yaml')));
+    });
+
+});
+
+function fixtureUri(...segments: string[]): vscode.Uri {
+    const folders = vscode.workspace.workspaceFolders;
+    assert.ok(folders && folders.length > 0, 'expected the fixture workspace to be open');
+    return vscode.Uri.file(path.join(folders[0].uri.fsPath, ...segments));
+}

--- a/test/suite/kustomize-patch-index.test.ts
+++ b/test/suite/kustomize-patch-index.test.ts
@@ -4,14 +4,21 @@ import * as yaml from 'js-yaml';
 
 import { patchFilePaths } from '../../src/yaml-support/kustomize-patch-index';
 
-const DIR = path.resolve(path.sep, 'work', 'overlays', 'local');
+// Mirrors normalisePath in the module under test. Without it the expected values keep the
+// drive-letter casing path.resolve produces, while the production code lowercases it, and
+// every positive assertion fails on the windows-latest leg of CI.
+function normalise(fsPath: string): string {
+    return process.platform === 'win32' ? fsPath.toLowerCase() : fsPath;
+}
+
+const DIR = normalise(path.resolve(path.sep, 'work', 'overlays', 'local'));
 
 function pathsIn(kustomizationYaml: string): readonly string[] {
     return patchFilePaths(yaml.load(kustomizationYaml), DIR);
 }
 
 function resolved(...segments: string[]): string {
-    return path.resolve(DIR, ...segments);
+    return normalise(path.resolve(DIR, ...segments));
 }
 
 suite("Kustomize patch index", () => {

--- a/test/suite/kustomize-patch-index.test.ts
+++ b/test/suite/kustomize-patch-index.test.ts
@@ -1,0 +1,140 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as yaml from 'js-yaml';
+
+import { patchFilePaths } from '../../src/yaml-support/kustomize-patch-index';
+
+const DIR = path.resolve(path.sep, 'work', 'overlays', 'local');
+
+function pathsIn(kustomizationYaml: string): readonly string[] {
+    return patchFilePaths(yaml.load(kustomizationYaml), DIR);
+}
+
+function resolved(...segments: string[]): string {
+    return path.resolve(DIR, ...segments);
+}
+
+suite("Kustomize patch index", () => {
+    suite("patchFilePaths method", () => {
+
+        test("...finds paths under patches", () => {
+            const paths = pathsIn(`
+patches:
+  - path: patch-deployment.yaml
+    target:
+      kind: Deployment
+`);
+            assert.deepStrictEqual([resolved('patch-deployment.yaml')], [...paths]);
+        });
+
+        test("...finds paths under the deprecated patchesStrategicMerge", () => {
+            const paths = pathsIn(`
+patchesStrategicMerge:
+  - patch-gateway.yaml
+  - patch-admin.yaml
+`);
+            assert.deepStrictEqual([resolved('patch-gateway.yaml'), resolved('patch-admin.yaml')], [...paths]);
+        });
+
+        test("...finds paths under the deprecated patchesJson6902", () => {
+            const paths = pathsIn(`
+patchesJson6902:
+  - path: replica-count.yaml
+    target:
+      kind: Deployment
+      name: server
+`);
+            assert.deepStrictEqual([resolved('replica-count.yaml')], [...paths]);
+        });
+
+        test("...resolves relative to the kustomization directory", () => {
+            const paths = pathsIn(`
+patches:
+  - path: ../shared/patch-resources.yaml
+`);
+            assert.deepStrictEqual([resolved('..', 'shared', 'patch-resources.yaml')], [...paths]);
+        });
+
+        test("...ignores resources, which are complete objects", () => {
+            const paths = pathsIn(`
+resources:
+  - deployment.yaml
+  - service.yaml
+`);
+            assert.deepStrictEqual([], [...paths]);
+        });
+
+        test("...ignores inline patches, which name no file", () => {
+            const paths = pathsIn(`
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 2
+    target:
+      kind: Deployment
+`);
+            assert.deepStrictEqual([], [...paths]);
+        });
+
+        test("...ignores inline patchesStrategicMerge entries", () => {
+            const paths = pathsIn(`
+patchesStrategicMerge:
+  - |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: server
+    spec:
+      replicas: 2
+`);
+            assert.deepStrictEqual([], [...paths]);
+        });
+
+        test("...ignores remote references", () => {
+            const paths = pathsIn(`
+patches:
+  - path: https://example.com/patch.yaml
+  - path: git@github.com:someone/repo.git
+  - path: github.com/someone/repo/patch.yaml
+patchesStrategicMerge:
+  - https://example.com/other.yaml
+`);
+            assert.deepStrictEqual([], [...paths]);
+        });
+
+        test("...collects from every patch field at once", () => {
+            const paths = pathsIn(`
+resources:
+  - ../../base
+patches:
+  - path: a.yaml
+patchesJson6902:
+  - path: b.yaml
+    target:
+      kind: Service
+patchesStrategicMerge:
+  - c.yaml
+`);
+            assert.deepStrictEqual([resolved('a.yaml'), resolved('b.yaml'), resolved('c.yaml')], [...paths]);
+        });
+
+        test("...tolerates an empty document", () => {
+            assert.deepStrictEqual([], [...patchFilePaths(yaml.load(''), DIR)]);
+        });
+
+        test("...tolerates patch fields of the wrong shape", () => {
+            const paths = pathsIn(`
+patches: not-a-list
+patchesStrategicMerge:
+  - 42
+  - null
+patchesJson6902:
+  - target:
+      kind: Deployment
+`);
+            assert.deepStrictEqual([], [...paths]);
+        });
+
+    });
+});


### PR DESCRIPTION
## What

Implements the TODO in `inferShouldProvideSchemaFor`:

> In future we may want to be smarter, e.g. detecting things which look like Kustomize
> patch files.

Files a `kustomization.yaml` names as patches are now excluded by the consideration
filter.

## Why

Patch files are partial resources by design — they carry only the fields to be merged over
a base — so validating them as complete objects reports problems with a file that is
correct:

```yaml
# overlays/local/patch-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: server
spec:
  replicas: 2
  template:
    spec:
      containers:
        - name: server
          resources:
            requests:
              cpu: "500m"
              memory: "768Mi"
```

`Missing property "selector"` from the schema, plus three `resource-limits` warnings.
Nothing here is wrong; the merged output is complete.

## How

A patch isn't recognisable from its own contents — it looks like a truncated resource, and
so does a resource someone is halfway through writing. What identifies it is that a
kustomization names it. `kustomize-patch-index.ts` indexes what the workspace's
kustomizations point at.

The lookup has to be synchronous (vscode-yaml's contributor API is synchronous, and
linting runs on every keystroke), so the index is maintained in the background by a
`FileSystemWatcher` rather than reading kustomization.yaml on demand. Activation doesn't
block on the initial scan; `onDidChange` tells consumers to reconsider when it lands.

Only patch fields are indexed — `patches[].path`, and the deprecated
`patchesStrategicMerge` and `patchesJson6902[].path`. Entries under `resources` are
complete objects and keep their schema and lint support. Inline patches and remote
references name no local file and are skipped.

## Trade-offs I'd like your view on

1. **Patch files lose completion too**, since this excludes them from schema support
   rather than only from diagnostics. That seems the right trade against reporting errors
   that aren't real, and `# vscode-kubernetes-tools: include` overrides it per file — but
   if you'd rather suppress only diagnostics, that's a different mechanism and I'm happy
   to go that way instead.

2. **Already-open documents don't refresh** when the index changes. `updateYAMLSchema`
   can only invalidate — per the vscode-yaml limitation your own comment there records.
   Newly opened documents are correct.

## Relationship to #2008

Independent; they compose. This one fixes the schema errors on its own. The
`resource-limits` warnings go away once the linter consults the same filter, which is
#2008. Neither depends on the other to merge.

## Testing

- `npm test` — 73 passing (was 57). Path extraction is covered directly (11 cases:
  each patch field, relative paths, `resources` left alone, inline patches, remote
  references, malformed input). The index itself is exercised against a fixture
  workspace, which `runTest.ts` now opens — tests that use untitled documents are
  unaffected by having a workspace open.
- I checked the workspace tests actually bite by breaking the lookup and confirming the
  positive case fails.
- `npm run lint` — clean, no new warnings.

The index is driven directly by those tests rather than through extension activation:
tests run against the TypeScript output in `out/`, whereas activating the extension loads
the webpack bundle in `dist/`, which `npm test` doesn't rebuild.
